### PR TITLE
fix(deploy): use semantic release for deployment to PyPI

### DIFF
--- a/ladybug_geometry/__init__.py
+++ b/ladybug_geometry/__init__.py
@@ -1,6 +1,4 @@
 import sys
 
-__version__ = '0.0.1'
-
 # This is a variable to check if the library is a [+] library.
 setattr(sys.modules[__name__], 'isplus', False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[semantic_release]
-version_variable = ladybug_geometry/__init__.py:__version__
-
 [bdist_wheel]
 universal = 1
 

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,19 @@
-import re
 import setuptools
-import sys
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-with open('ladybug_geometry/__init__.py', 'r') as fd:
-    version = re.search(
-        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-        fd.read(),
-        re.MULTILINE
-    ).group(1)
-
-try:
-    from semantic_release import setup_hook
-    setup_hook(sys.argv)
-except ImportError:
-    pass
-
 setuptools.setup(
     name="ladybug-geometry",
-    version=version,
+    use_scm_version = True,
+    setup_requires=['setuptools_scm'],
     author="Ladybug Tools",
     author_email="info@ladybug.tools",
     description="Ladybug geometry is a Python library that adds geometry objects and basic geometric computation to Ladybug.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/ladybug-tools/ladybug-geometry",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests"]),
     install_requires=[
     ],
     classifiers=[


### PR DESCRIPTION
The version for PyPI was set to the hard-coded version in \__init__.py. This is now fixed.