### PR TITLE
 fix(tolerance): Ensuring values are valid when <= tolerance

### DIFF
--- a/ladybug_geometry/geometry2d/polygon.py
+++ b/ladybug_geometry/geometry2d/polygon.py
@@ -327,7 +327,7 @@ class Polygon2D(Base2DIn2D):
         for i, _v in enumerate(self.vertices):
             _a = self[i - 2].determinant(self[i - 1]) + self[i - 1].determinant(_v) + \
                 _v.determinant(self[i - 2])
-            if abs(_a) > tolerance:
+            if abs(_a) >= tolerance:
                 new_vertices.append(self[i - 1])
         return Polygon2D(new_vertices)
 

--- a/ladybug_geometry/geometry3d/_1d.py
+++ b/ladybug_geometry/geometry3d/_1d.py
@@ -79,7 +79,7 @@ class Base1DIn3D(object):
         if not self.is_parallel(line_ray, angle_tolerance):
             return False
         _close_pt = closest_point3d_on_line3d_infinite(self.p, line_ray)
-        if self.p.distance_to_point(_close_pt) > tolerance:
+        if self.p.distance_to_point(_close_pt) >= tolerance:
             return False
         return True
 

--- a/ladybug_geometry/geometry3d/_2d.py
+++ b/ladybug_geometry/geometry3d/_2d.py
@@ -42,10 +42,7 @@ class Base2DIn3D(object):
 
     @property
     def center(self):
-        """A Point3D for the center of the bounding box around this geometry.
-
-        For a Surface3D, this point will always lie within the plane of the surface.
-        """
+        """A Point3D for the center of the bounding box around this geometry."""
         if self._center is None:
             min, max = self.min, self.max
             self._center = Point3D(

--- a/ladybug_geometry/geometry3d/line.py
+++ b/ladybug_geometry/geometry3d/line.py
@@ -78,7 +78,7 @@ class LineSegment3D(Base1DIn3D):
             tolerance: The maximum difference between the z values of the start and
                 end coordinates at which the line segment is considered horizontal.
         """
-        return abs(edge.v.z) < tolerance
+        return abs(edge.v.z) <= tolerance
 
     def is_vertical(edge, tolerance):
         """Test whether this line segment is vertical within a certain tolerance.
@@ -87,7 +87,7 @@ class LineSegment3D(Base1DIn3D):
             tolerance: The maximum difference between the x and y values of the start
                 and end coordinates at which the line segment is considered horizontal.
         """
-        return abs(edge.v.x) < tolerance and abs(edge.v.y) < tolerance
+        return abs(edge.v.x) <= tolerance and abs(edge.v.y) <= tolerance
 
     def flip(self):
         """Get a copy of this line segment that is flipped."""

--- a/ladybug_geometry/geometry3d/plane.py
+++ b/ladybug_geometry/geometry3d/plane.py
@@ -338,9 +338,9 @@ class Plane(object):
         Returns:
             True if plane is coplanar. False if it is not coplanar.
         """
-        if self.n.angle(plane.n) < angle_tolerance or \
-                self.n.angle(plane.n.reverse()) < angle_tolerance:
-            return self.distance_to_point(plane.o) < tolerance
+        if self.n.angle(plane.n) <= angle_tolerance or \
+                self.n.angle(plane.n.reverse()) <= angle_tolerance:
+            return self.distance_to_point(plane.o) <= tolerance
         return False
 
     def duplicate(self):

--- a/ladybug_geometry/geometry3d/polyface.py
+++ b/ladybug_geometry/geometry3d/polyface.py
@@ -201,21 +201,21 @@ class Polyface3D(Base2DIn3D):
         return cls(vertices, face_indices)
 
     @classmethod
-    def from_box(cls, length, width, height, base_plane=None):
+    def from_box(cls, width, depth, height, base_plane=None):
         """Initilize Polyface3D from parameters describing a box.
 
         Initializing a polyface this way has the added benefit of having its
         faces property quickly calculated.
 
         Args:
-            length: A number for the length of the box (in the X direction).
-            width: A number for the width of the box (in the Y direction).
+            width: A number for the width of the box (in the X direction).
+            depth: A number for the depth of the box (in the Y direction).
             height: A number for the height of the box (in the Z direction).
             base_plane: A Plane object from which to generate the box.
                 If None, default is the WorldXY plane.
         """
-        assert isinstance(length, (float, int)), 'Box length must be a number.'
         assert isinstance(width, (float, int)), 'Box width must be a number.'
+        assert isinstance(depth, (float, int)), 'Box depth must be a number.'
         assert isinstance(height, (float, int)), 'Box height must be a number.'
         if base_plane is not None:
             assert isinstance(base_plane, Plane), \
@@ -223,21 +223,21 @@ class Polyface3D(Base2DIn3D):
         else:
             base_plane = Plane(Vector3D(0, 0, 1), Point3D())
         _o = base_plane.o
-        _l_vec = base_plane.x * length
-        _w_vec = base_plane.y * width
+        _w_vec = base_plane.x * width
+        _d_vec = base_plane.y * depth
         _h_vec = base_plane.n * height
-        _verts = (_o, _o + _w_vec, _o + _w_vec + _l_vec, _o + _l_vec,
-                  _o + _h_vec, _o + _w_vec + _h_vec,
-                  _o + _w_vec + _l_vec + _h_vec, _o + _l_vec + _h_vec)
-        _face_indices = ([(0, 1, 2, 3)], [(0, 4, 5, 1)], [(0, 3, 7, 4)],
-                         [(2, 1, 5, 6)], [(6, 7, 3, 2)], [(7, 6, 5, 4)])
+        _verts = (_o, _o + _d_vec, _o + _d_vec + _w_vec, _o + _w_vec,
+                  _o + _h_vec, _o + _d_vec + _h_vec,
+                  _o + _d_vec + _w_vec + _h_vec, _o + _w_vec + _h_vec)
+        _face_indices = ([(0, 1, 2, 3)], [(2, 1, 5, 6)], [(6, 7, 3, 2)],
+                         [(0, 3, 7, 4)], [(0, 4, 5, 1)], [(7, 6, 5, 4)])
         _edge_indices = ((3, 0), (0, 1), (1, 2), (2, 3), (0, 4), (4, 5),
                          (5, 1), (3, 7), (7, 4), (6, 2), (5, 6), (6, 7))
         polyface = cls(_verts, _face_indices, {'edge_indices': _edge_indices,
                                                'edge_types': [1] * 12})
         verts = tuple(tuple(_verts[i] for i in face[0]) for face in _face_indices)
         polyface._faces = tuple(Face3D(v, enforce_right_hand=False) for v in verts)
-        polyface._volume = length * width * height
+        polyface._volume = width * depth * height
         return polyface
 
     @classmethod
@@ -461,9 +461,8 @@ class Polyface3D(Base2DIn3D):
         Args:
             tolerance: The minimum distance between a vertex and the boundary segments
                 at which point the vertex is considered colinear.
-            angle_tolerance: The max angle in radians that the direction between
-                this object and another can vary for them to be considered
-                parallel.
+            angle_tolerance: The max angle in radians that vertices are allowed to
+                 differ from one another in order to consider them colinear.
         """
         # get naked edges
         naked_edges = list(self.naked_edges)

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -287,8 +287,8 @@ class Face3DTestCase(unittest.TestCase):
         assert face.is_convex is False
         assert face.is_self_intersecting is False
 
-    def test_is_equivalent(self):
-        """Test the is_equivalent method."""
+    def test_is_geometrically_equivalent(self):
+        """Test the is_geometrically_equivalent method."""
         plane_1 = Plane(Vector3D(0, 0, 1))
         plane_2 = Plane(Vector3D(0, 0, -1))
         pts_1 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 2), Point3D(0, 2))


### PR DESCRIPTION
I made a pretty grave mistake throughout several uses of tolerance in the geometry library in that I only had values equal when they were < tolerance instead of <= tolerance.  This created lots of issues when I wanted to use 0 tolerance for a few things and it s now fixed.

There are also a few minor style changes that were made for better consistency with soon-to-come honeybee-core edits.