### PR TITLE
perf(slots): Fixed the Implementation of __slots__ in Inheritance

### DIFF
--- a/ladybug_geometry/_mesh.py
+++ b/ladybug_geometry/_mesh.py
@@ -20,6 +20,8 @@ class MeshBase(object):
         face_centroids
         vertex_connected_faces
     """
+    __slots__ = ('_vertices', '_faces', '_colors', '_is_color_by_face',
+                 '_area', '_face_areas', '_face_centroids', '_vertex_connected_faces')
 
     def __init__(self, vertices, faces, colors=None):
         """Initilize MeshBase.
@@ -32,7 +34,7 @@ class MeshBase(object):
                 of the mesh or the vertices of the mesh. Default is None.
         """
         self._vertices = vertices
-        self._check_faces_input(faces)
+        self._faces = self._check_faces_input(faces)
         self._is_color_by_face = False  # default if colors is None
         self.colors = colors
         self._area = None
@@ -138,6 +140,10 @@ class MeshBase(object):
         _verts = tuple(pt.reflect(normal, origin) for pt in self.vertices)
         return self._mesh_transform(_verts)
 
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
+
     def _check_faces_input(self, faces):
         """Check input faces for correct formatting."""
         if not isinstance(faces, tuple):
@@ -159,7 +165,7 @@ class MeshBase(object):
                     raise TypeError(
                         'Mesh face must use integers to reference vertices. '
                         'Got {}.'.format(type(ind)))
-        self._faces = faces
+        return faces
 
     def _check_face_pattern(self, pattern):
         """Check input pattern for remove faces for compatibility with this mesh."""
@@ -323,3 +329,20 @@ class MeshBase(object):
                     ver_counter += 1
                 face_collector.append(tuple(ind))
         return vertices, face_collector
+
+    def __len__(self):
+        return len(self.vertices)
+
+    def __getitem__(self, key):
+        return self.vertices[key]
+
+    def __iter__(self):
+        return iter(self.vertices)
+
+    def ToString(self):
+        """Overwrite .NET ToString."""
+        return self.__repr__()
+
+    def __repr__(self):
+        """Base MEsh representation."""
+        return 'Base Mesh Object'

--- a/ladybug_geometry/geometry2d/_1d.py
+++ b/ladybug_geometry/geometry2d/_1d.py
@@ -13,6 +13,7 @@ class Base1DIn2D(object):
         p: End Point2D of object
         v: Vector2D along object
     """
+    __slots__ = ('_p', '_v')
 
     def __init__(self, p, v):
         """Initilize Base1DIn2D.

--- a/ladybug_geometry/geometry2d/_2d.py
+++ b/ladybug_geometry/geometry2d/_2d.py
@@ -14,6 +14,7 @@ class Base2DIn2D(object):
         max
         center
     """
+    __slots__ = ('_vertices', '_min', '_max', '_center')
 
     def __init__(self, vertices):
         """Initilize Base2DIn2D.
@@ -21,10 +22,15 @@ class Base2DIn2D(object):
         Args:
             vertices: A list of Point2D objects representing the vertices.
         """
-        self._check_vertices_input(vertices)
+        self._vertices = self._check_vertices_input(vertices)
         self._min = None
         self._max = None
         self._center = None
+
+    @property
+    def vertices(self):
+        """Tuple of all vertices in this object."""
+        return self._vertices
 
     @property
     def min(self):
@@ -79,7 +85,7 @@ class Base2DIn2D(object):
             assert isinstance(vert, Point2D), \
                 'Expected Point2D for {} vertex. Got {}.'.format(
                     self.__class__.__name__, type(vert))
-        self._vertices = vertices
+        return vertices
 
     def __len__(self):
         return len(self.vertices)

--- a/ladybug_geometry/geometry2d/line.py
+++ b/ladybug_geometry/geometry2d/line.py
@@ -17,7 +17,7 @@ class LineSegment2D(Base1DIn2D):
         p2: Second point
         length: The length of the line segement
     """
-    __slots__ = ('_p', '_v')
+    __slots__ = ()
 
     def __init__(self, p, v):
         """Initilize LineSegment2D.

--- a/ladybug_geometry/geometry2d/pointvector.py
+++ b/ladybug_geometry/geometry2d/pointvector.py
@@ -268,6 +268,7 @@ class Point2D(Vector2D):
         x
         y
     """
+    __slots__ = ()
 
     def move(self, moving_vec):
         """Get a point that has been moved along a vector.

--- a/ladybug_geometry/geometry2d/polygon.py
+++ b/ladybug_geometry/geometry2d/polygon.py
@@ -29,8 +29,7 @@ class Polygon2D(Base2DIn2D):
         is_self_intersecting
         is_valid
     """
-    __slots__ = ('_vertices', '_segments', '_triangulated_mesh',
-                 '_min', '_max', '_center', '_perimeter', '_area',
+    __slots__ = ('_segments', '_triangulated_mesh', '_perimeter', '_area',
                  '_is_clockwise', '_is_convex', '_is_self_intersecting')
 
     def __init__(self, vertices):
@@ -39,7 +38,7 @@ class Polygon2D(Base2DIn2D):
         Args:
             vertices: A list of Point2D objects representing the vertices of the polygon.
         """
-        self._check_vertices_input(vertices)
+        self._vertices = self._check_vertices_input(vertices)
         self._segments = None
         self._triangulated_mesh = None
         self._min = None

--- a/ladybug_geometry/geometry2d/ray.py
+++ b/ladybug_geometry/geometry2d/ray.py
@@ -13,7 +13,7 @@ class Ray2D(Base1DIn2D):
         p: Base point
         v: Direction vector
     """
-    __slots__ = ('_p', '_v')
+    __slots__ = ()
 
     def __init__(self, p, v):
         """Initilize Ray2D.

--- a/ladybug_geometry/geometry3d/_1d.py
+++ b/ladybug_geometry/geometry3d/_1d.py
@@ -14,6 +14,7 @@ class Base1DIn3D(object):
         p: End Point3D of object
         v: Vector3D along object
     """
+    __slots__ = ('_p', '_v')
 
     def __init__(self, p, v):
         """Initilize Base1DIn3D.

--- a/ladybug_geometry/geometry3d/_2d.py
+++ b/ladybug_geometry/geometry3d/_2d.py
@@ -14,6 +14,7 @@ class Base2DIn3D(object):
         max
         center
     """
+    __slots__ = ('_vertices', '_min', '_max', '_center')
 
     def __init__(self, vertices):
         """Initilize Base2DIn3D.
@@ -21,10 +22,15 @@ class Base2DIn3D(object):
         Args:
             vertices: A list of Point3D objects representing the vertices.
         """
-        self._check_vertices_input(vertices)
+        self._vertices = self._check_vertices_input(vertices)
         self._min = None
         self._max = None
         self._center = None
+
+    @property
+    def vertices(self):
+        """Tuple of all vertices in this object."""
+        return self._vertices
 
     @property
     def min(self):
@@ -84,7 +90,7 @@ class Base2DIn3D(object):
             assert isinstance(vert, Point3D), \
                 'Expected Point3D for {} vertex. Got {}.'.format(
                     self.__class__.__name__, type(vert))
-        self._vertices = vertices
+        return vertices
 
     def __len__(self):
         return len(self.vertices)

--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -51,10 +51,10 @@ class Face3D(Base2DIn3D):
         has_holes
         upper_left_counter_clockwise_vertices
     """
-    __slots__ = ('_vertices', '_plane', '_polygon2d', '_mesh2d', '_mesh3d',
+    __slots__ = ('_plane', '_polygon2d', '_mesh2d', '_mesh3d',
                  '_boundary', '_holes', '_boundary_segments', '_hole_segments',
                  '_boundary_polygon2d', '_hole_polygon2d',
-                 '_min', '_max', '_center', '_perimeter', '_area', '_centroid',
+                 '_perimeter', '_area', '_centroid',
                  '_is_convex', '_is_self_intersecting')
 
     def __init__(self, boundary, plane=None, holes=None, enforce_right_hand=True):

--- a/ladybug_geometry/geometry3d/line.py
+++ b/ladybug_geometry/geometry3d/line.py
@@ -16,7 +16,7 @@ class LineSegment3D(Base1DIn3D):
         p2: Second point
         length: The length of the line segement
     """
-    __slots__ = ('_p', '_v')
+    __slots__ = ()
 
     def __init__(self, p, v):
         """Initilize LineSegment3D.

--- a/ladybug_geometry/geometry3d/pointvector.py
+++ b/ladybug_geometry/geometry3d/pointvector.py
@@ -298,6 +298,7 @@ class Point3D(Vector3D):
         y
         z
     """
+    __slots__ = ()
 
     def move(self, moving_vec):
         """Get a point that has been moved along a vector.

--- a/ladybug_geometry/geometry3d/polyface.py
+++ b/ladybug_geometry/geometry3d/polyface.py
@@ -35,10 +35,10 @@ class Polyface3D(Base2DIn3D):
         volume
         is_solid
     """
-    __slots__ = ('_vertices', '_faces', '_edges',
+    __slots__ = ('_faces', '_edges',
                  '_naked_edges', '_internal_edges', '_non_manifold_edges',
-                 '_face_indices', '_edge_indices', '_edge_types'
-                 '_min', '_max', '_center', '_area', '_is_solid')
+                 '_face_indices', '_edge_indices', '_edge_types',
+                 '_area', '_volume', '_is_solid')
 
     def __init__(self, vertices, face_indices, edge_information=None):
         """Initilize Polyface3D.
@@ -65,7 +65,7 @@ class Polyface3D(Base2DIn3D):
                     non-manifold edge.
         """
         # assign input properties
-        self._check_vertices_input(vertices)
+        self._vertices = self._check_vertices_input(vertices)
         self._face_indices = tuple(tuple(tuple(loop) for loop in face)
                                    for face in face_indices)
 

--- a/ladybug_geometry/geometry3d/ray.py
+++ b/ladybug_geometry/geometry3d/ray.py
@@ -13,7 +13,7 @@ class Ray3D(Base1DIn3D):
         p: Base point
         v: Direction vector
     """
-    __slots__ = ('_p', '_v')
+    __slots__ = ()
 
     def __init__(self, p, v):
         """Initilize Ray3D.


### PR DESCRIPTION
The previous implementation of __slots__ was not correct across the inheritance tree.  So it was not doing anything for the vast majority of geometry objects.  This commit fixes this.
In the process, I realized that I had to give up the dual inheritance of Mesh objects since both of the objects it had previously inherited from have a `vertices` attribute.  However, this hasn't increased the extra code by any more than 100 lines and is a small price to pay for the functionality of __slots__.