### PR TITLE
fix(polyface): Ensuring that from_box preserves base_plane orientation

### DIFF
--- a/ladybug_geometry/geometry3d/polyface.py
+++ b/ladybug_geometry/geometry3d/polyface.py
@@ -202,7 +202,11 @@ class Polyface3D(Base2DIn3D):
         polyface = cls(_verts, _face_indices, {'edge_indices': _edge_indices,
                                                'edge_types': [1] * 12})
         verts = tuple(tuple(_verts[i] for i in face[0]) for face in _face_indices)
-        polyface._faces = tuple(Face3D(v, enforce_right_hand=False) for v in verts)
+        top_plane = base_plane.move(_h_vec)
+        bottom = (Face3D(verts[0], plane=base_plane, enforce_right_hand=False),)
+        middle = tuple(Face3D(v, enforce_right_hand=False) for v in verts[1:5])
+        top = (Face3D(verts[5], plane=top_plane, enforce_right_hand=False),)
+        polyface._faces = bottom + middle + top
         polyface._volume = width * depth * height
         return polyface
 

--- a/tests/polyface3d_test.py
+++ b/tests/polyface3d_test.py
@@ -478,6 +478,20 @@ def test_min_max_center():
     assert polyface_2.volume == pytest.approx(4, rel=1e-3)
 
 
+def test_floor_mesh_grid():
+    """Test the generation of a mesh grid from the floor of a box."""
+    polyface = Polyface3D.from_box(5, 10, 3)
+    floor_grid = polyface.faces[0].get_mesh_grid(1, 1, 1, True)
+    assert len(floor_grid.faces) == 50
+
+    angle = -1 * math.radians(45)
+    x_axis = Vector3D(1, 0, 0).rotate_xy(angle)
+    base_plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 0), x_axis)
+    polyface = Polyface3D.from_box(5, 10, 3, base_plane)
+    floor_grid = polyface.faces[0].get_mesh_grid(1, 1, 1, True)
+    assert len(floor_grid.faces) == 50
+
+
 def test_duplicate():
     """Test the duplicate method of Face3D."""
     polyface = Polyface3D.from_box(2, 4, 2)


### PR DESCRIPTION
Small fix to ensure that mesh grids that are generated from a box floor are correctly oriented to the box plane.