### PR TITLE
style(face3d): Changing validate_planarity to check_planar

### DIFF
--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -472,7 +472,7 @@ class Face3D(Base2DIn3D):
         """Boolean noting whether the face is valid (having a non-zero area).
 
         Note that faces are still considered valid if they have out-of-plane vertices,
-        self-intersecting edges, or duplicate/colinear vertices. The validate_planarity
+        self-intersecting edges, or duplicate/colinear vertices. The check_planar
         method can be used to detect if there are out-of-plane vertices. The
         is_self_intersecting property identifies self-intersecting edges, and the
         remove_colinear_vertices method will remove duplicate/colinear vertices."""
@@ -654,8 +654,8 @@ class Face3D(Base2DIn3D):
                     return False
             return True
 
-    def validate_planarity(self, tolerance, raise_exception=True):
-        """Validate that all of the face's vertices lie within the face's plane.
+    def check_planar(self, tolerance, raise_exception=True):
+        """Check that all of the face's vertices lie within the face's plane.
 
         This check is not done by default when creating the face since
         it is assumed that there is likely a check for planarity before the face

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -575,8 +575,8 @@ def test_triangulated_mesh_and_centroid():
     assert face_2.centroid.z == 0
 
 
-def test_validate_planarity():
-    """Test the validate_planarity method of Face3D."""
+def test_check_planar():
+    """Test the check_planar method of Face3D."""
     pts_1 = (Point3D(0, 0, 2), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
     pts_2 = (Point3D(0, 0, 0), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
     pts_3 = (Point3D(0, 0, 2.0001), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
@@ -585,14 +585,14 @@ def test_validate_planarity():
     face_2 = Face3D(pts_2, plane_1)
     face_3 = Face3D(pts_3, plane_1)
 
-    assert face_1.validate_planarity(0.001) is True
-    assert face_2.validate_planarity(0.001, False) is False
+    assert face_1.check_planar(0.001) is True
+    assert face_2.check_planar(0.001, False) is False
     with pytest.raises(Exception):
-        face_2.validate_planarity(0.0001)
-    assert face_3.validate_planarity(0.001) is True
-    assert face_3.validate_planarity(0.000001, False) is False
+        face_2.check_planar(0.0001)
+    assert face_3.check_planar(0.001) is True
+    assert face_3.check_planar(0.000001, False) is False
     with pytest.raises(Exception):
-        face_3.validate_planarity(0.000001)
+        face_3.check_planar(0.000001)
 
 
 def test_flip():


### PR DESCRIPTION
The word "check" is a lot more generic and easier to remember than "validate".  So I changed all of the checking functions in honeybee-core to use the word "check" instead of "validate".  Now I am changing ladybug-geometry to follow the same convention.