### PR TITLE
fix(docs): build docs in separate step to PyPi deployment

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,7 +4,7 @@
         "@semantic-release/release-notes-generator",
         "@semantic-release/github",
         ["@semantic-release/exec", {
-            "publishCmd": "bash deploy.sh ${nextRelease.version}"
+            "publishCmd": "bash deploy.sh"
         }]
     ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,11 @@ jobs:
     - git config --global user.email "releases@ladybug.tools"
     - git config --global user.name "ladybugbot"
     - npx semantic-release
+  - stage: docs
+    if: branch = master AND (NOT type IN (pull_request))
+    script:
+    - sphinx-apidoc -f -e -d 4 -o ./docs ./ladybug_geometry
+    - sphinx-build -b html ./docs ./docs/_build/docs
     deploy:
       provider: pages
       skip_cleanup: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,26 +1,6 @@
 #!/bin/sh
 
-deploy_to_pypi() {
-  echo "Building distribution"
-  python setup.py sdist bdist_wheel
-  echo "Pushing new version to PyPi"
-  twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD 
-}
-
-build_docs() {
-  echo "Building documentation files"
-  sphinx-apidoc -f -e -d 4 -o ./docs ./ladybug_geometry
-  sphinx-build -b html ./docs ./docs/_build/docs -D release=$1 -D version=$1
-}
-
-
-if [ -n "$1" ]
-then
-  NEXT_RELEASE_VERSION=$1
-else
-  echo "A release version must be supplied"
-  exit 1
-fi
-
-deploy_to_pypi
-build_docs $NEXT_RELEASE_VERSION
+echo "Building distribution"
+python setup.py sdist bdist_wheel
+echo "Pushing new version to PyPi"
+twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD 


### PR DESCRIPTION
This commit is trying to bring this repo in sync with the structure of the ladybug tool template repo. It's taking a cue from [this commit here](https://github.com/ladybug-tools/honeybee-core/commit/deeb42245bf83a168d9440fcff3ad3bf8aafa39f).

We can hold off on merging this PR until we get confirmation that I did this correctly on [this PR](https://github.com/ladybug-tools/ladybug-comfort/pull/38) and santiago's PR gets merged and I bring this fork in sync with his changes.