### PR TITLE
Added alternate method for generating Face3D sub-faces

### DIFF
--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -1260,16 +1260,14 @@ class Face3D(Base2DIn3D):
                                          for i, pt in enumerate(btm_div_pts[:-1]))
             # scale the line segments along their center points
             line_cent_pt = [
-                Point3D(LineSegment3D.from_end_points(line.p1, line.p2).midpoint.x,
-                        0, line.p1.z)
+                LineSegment3D.from_end_points(line.p1, line.p2).point_at(0.5)
                 for line in sub_face_lines_start
             ]
 
             sub_face_line_scale = sub_face_width / div_dist
 
             sub_face_lines_start = tuple(LineSegment3D.from_end_points(
-                Point3D(a.p1.scale(sub_face_line_scale, b).x, 0, a.p1.z),
-                Point3D(a.p2.scale(sub_face_line_scale, b).x, 0, a.p1.z))
+                a.p1, a.p2).scale(sub_face_line_scale, b)
                 for a, b in zip(sub_face_lines_start, line_cent_pt)
             )
             # generate the vertices by 'extruding' along window height vector

--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -1187,7 +1187,7 @@ class Face3D(Base2DIn3D):
             sub_faces.extend(face.sub_faces_by_ratio(ratio))
         return sub_faces
 
-    def __sub_faces_by_dimensions(self, sub_face_height, sub_face_width, wall_length,
+    def _sub_faces_by_dimensions(self, sub_face_height, sub_face_width, wall_length,
                                 dist_breakup, sill_height, rect_height, changed_var):
         """Get a list of faces with a combined area equal to the glazing ratio
         times this face area. The glazing ratio is derived internally using the

--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -1187,6 +1187,136 @@ class Face3D(Base2DIn3D):
             sub_faces.extend(face.sub_faces_by_ratio(ratio))
         return sub_faces
 
+    def sub_faces_by_dimensions(self, window_height, window_width, wall_length,
+                                dist_breakup, sill_height, rect_height, changed_var):
+        """Get a list of faces with a combined area equal to the glazing ratio
+        times this face area. The glazing ratio is derived internally using the
+        specified window height and width along with other parameters.
+
+        All sub faces will lie inside the boundaries of this face.
+
+        Args:
+            height: window height
+            width: window width
+            wall_length: total length (width) of window wall
+            dist_breakup: distance by which main rectangle is meant to be 
+                divided up into points on the bottom
+            sill_height: A number for the target height above the bottom edge of
+                the rectangle to start the sub-rectangles. Note that, if the
+                ratio is too large for the height, the ratio will take precedence
+                and the sub-rectangle height will be smaller than this value.
+            rect_height: A number for the target height of the output rectangles. Note that, if the ratio is too large for the height,
+                the ratio will take precedence and the sub-rectangle height will
+                be larger than this value.
+            changed_var: string indicating the variable being changed 
+
+        Returns:
+            A list of Face3D objects for sub faces.
+        """
+        win_height_final = window_height
+        if window_height > rect_height:
+            win_height_final = rect_height
+
+        sill_height_final = sill_height
+        if sill_height < 0.01 * rect_height:
+            sill_height_final = 0
+        elif sill_height > rect_height-0.1:
+            sill_height_final = rect_height-0.1
+
+        if win_height_final + sill_height_final > rect_height:
+            if changed_var == "sill_height_value":
+                win_height_final = rect_height - sill_height_final
+            else:
+                sill_height_final = rect_height - win_height_final
+
+        max_width_break_up = wall_length/2
+
+        if wall_length > dist_breakup/2:
+            num_divisions = round(wall_length/dist_breakup)
+        else:
+            num_divisions = 1
+        if window_width < max_width_break_up and num_divisions * window_width <= wall_length and num_divisions != 1:
+            if num_divisions == 1:
+                div_dist = wall_length/2
+            elif num_divisions * window_width + (num_divisions-1) * (dist_breakup - window_width) > wall_length:
+                num_divisions = math.floor(wall_length/dist_breakup)
+                div_dist = dist_breakup
+            else:
+                div_dist = dist_breakup
+
+            is_odd = lambda num: num % 2
+            if is_odd(num_divisions) == 0:
+                start_pt_x = (num_divisions / 2) * div_dist
+            else:
+                start_pt_x = (math.floor(num_divisions / 2) + 0.5) * div_dist
+
+            btm_div_pts = [[start_pt_x, 0, sill_height_final]]
+            remainder = wall_length - (div_dist * num_divisions)
+            total_dist = remainder/2
+
+            while total_dist < wall_length:
+                total_dist += div_dist
+                next_pt = (wall_length / 2) - total_dist
+                btm_div_pts.append([next_pt, 0, sill_height_final])
+
+            win_lines_start = []
+            pt_index = 0
+            for i in range(len(btm_div_pts)):
+                point = btm_div_pts[i]
+                if pt_index < num_divisions:
+                    win_lines_start.append([point, btm_div_pts[pt_index+1]])
+                    pt_index += 1
+
+            line_cent_pt = []
+            for i in range(len(win_lines_start)):
+                line = win_lines_start[i]
+                line_cent_pt.append([line[1][0]+((line[0][0]-line[1][0])/2), 0, line[0][2]])
+            if num_divisions != 1:
+                dist_cent_line = div_dist
+            else:
+                dist_cent_line = wall_length
+
+            win_line_scale = window_width / div_dist
+
+            for i in range(len(win_lines_start)):
+                line = win_lines_start[i]
+                line_center_pt = line_cent_pt[i]
+                new_start_pt = [line[0][0] - ((line[0][0]-line_center_pt[0])*(1-win_line_scale)), 0, line[0][2]]
+                new_end_pt = [line[1][0] + ((line_center_pt[0]-line[1][0])*(1-win_line_scale)), 0, line[0][2]]
+                win_lines_start[i] = [new_start_pt, new_end_pt]
+
+            glz_area = 0
+            final_glz_coords = []
+            for i in range(len(win_lines_start)):
+                line = win_lines_start[i]
+                window_coord = []
+                window_coord.append(line[1])
+                window_coord.append(line[0])
+                window_coord.append([line[0][0], 0, line[0][2] + win_height_final])
+                window_coord.append([line[1][0], 0, line[1][2] + win_height_final])
+                final_glz_coords.append(window_coord)
+                glz_area += win_height_final * window_width
+        else:
+            if window_width > wall_length:
+                window_width = wall_length
+            win_lines_start = [[wall_length/2, 0, sill_height_final],[-wall_length/2, 0, sill_height_final]]
+
+            dist_cent_line = wall_length
+            win_line_scale = window_width / wall_length
+            line_cent_pt = [0,0,0]
+            new_start_pt = [win_lines_start[0][0] - ((win_lines_start[0][0]-line_cent_pt[0])*(1-win_line_scale)), 0, win_lines_start[0][2]]
+            new_end_pt = [win_lines_start[1][0] + ((line_cent_pt[0]-win_lines_start[1][0])*(1-win_line_scale)), 0, win_lines_start[0][2]]
+            win_lines_start = [new_start_pt, new_end_pt]
+
+            glz_area = win_height_final * window_width
+            final_glz_coords = []
+            final_glz_coords[0].append(win_lines_start[1])
+            final_glz_coords[0].append(win_lines_start[0])
+            final_glz_coords[0].append([win_lines_start[0][0], 0, win_lines_start[0][2] + win_height_final])
+            final_glz_coords[0].append([win_lines_start[1][0], 0, win_lines_start[1][2] + win_height_final])
+        glazing_ratio = glz_area/(wall_length * rect_height)
+        return self.sub_faces_by_ratio(glazing_ratio)
+
     def get_top_bottom_horizontal_edges(self, tolerance):
         """Get top and bottom horizontal edges of this Face if they exist.
 

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -1157,12 +1157,12 @@ def test_sub_faces_by_dimensions():
     rect_height = 6
     wall_length = 4
 
-    sub_faces_1 = face_1.__sub_faces_by_dimensions(
+    sub_faces_1 = face_1._sub_faces_by_dimensions(
         sub_face_height, 6.0, wall_length, 1.0, sill_height, rect_height, None)
     assert len(sub_faces_1) == 1
     assert sub_faces_1[0].area == pytest.approx(face_1.area * 0.5, rel=1e-3)
 
-    sub_faces_2 = face_2.__sub_faces_by_dimensions(
+    sub_faces_2 = face_2._sub_faces_by_dimensions(
         sub_face_height, 6.0, wall_length, 1.0, sill_height, rect_height, None)
     assert len(sub_faces_2) == 4
     areas = [srf.area for srf in sub_faces_2]

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -1144,26 +1144,26 @@ def test_sub_faces_by_ratio():
     assert sum(areas) == pytest.approx(face_2.area * 0.5, rel=1e-3)
 
 
-def test_sub_faces_by_dimensions():
-    """Test the sub_faces_by_dimensions method."""
-    pts_1 = (Point3D(0, 0), Point3D(0, 2), Point3D(2, 2), Point3D(2, 0))
-    pts_2 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 1), Point3D(1, 1),
-             Point3D(1, 2), Point3D(0, 2))
-    plane = Plane(Vector3D(0, 0, 1))
-    face_1 = Face3D(pts_1, plane)
-    face_2 = Face3D(pts_2, plane)
-    window_height = 2
+def test_sub_faces_by_dimensions():
+    """Test the sub_faces_by_dimensions method."""
+    pts_1 = (Point3D(0, 0), Point3D(0, 2), Point3D(2, 2), Point3D(2, 0))
+    pts_2 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 1), Point3D(1, 1),
+             Point3D(1, 2), Point3D(0, 2))
+    plane = Plane(Vector3D(0, 0, 1))
+    face_1 = Face3D(pts_1, plane)
+    face_2 = Face3D(pts_2, plane)
+    sub_face_height = 2
     sill_height = 1
     rect_height = 6
     wall_length = 4
 
-    sub_faces_1 = face_1.sub_faces_by_dimensions(
-        window_height, 6.0, wall_length, 1.0, sill_height, rect_height, None)
-    assert len(sub_faces_1) == 1
-    assert sub_faces_1[0].area == pytest.approx(face_1.area * 0.5, rel=1e-3)
+    sub_faces_1 = face_1.__sub_faces_by_dimensions(
+        sub_face_height, 6.0, wall_length, 1.0, sill_height, rect_height, None)
+    assert len(sub_faces_1) == 1
+    assert sub_faces_1[0].area == pytest.approx(face_1.area * 0.5, rel=1e-3)
 
-    sub_faces_2 = face_2.sub_faces_by_dimensions(
-        window_height, 6.0, wall_length, 1.0, sill_height, rect_height, None)
-    assert len(sub_faces_2) == 4
-    areas = [srf.area for srf in sub_faces_2]
-    assert sum(areas) == pytest.approx(face_2.area * 0.5, rel=1e-3)
+    sub_faces_2 = face_2.__sub_faces_by_dimensions(
+        sub_face_height, 6.0, wall_length, 1.0, sill_height, rect_height, None)
+    assert len(sub_faces_2) == 4
+    areas = [srf.area for srf in sub_faces_2]
+    assert sum(areas) == pytest.approx(face_2.area * 0.5, rel=1e-3)

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -1147,23 +1147,22 @@ def test_sub_faces_by_ratio():
 def test_sub_faces_by_dimensions():
     """Test the sub_faces_by_dimensions method."""
     pts_1 = (Point3D(0, 0), Point3D(0, 2), Point3D(2, 2), Point3D(2, 0))
-    pts_2 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 1), Point3D(1, 1),
-             Point3D(1, 2), Point3D(0, 2))
+    pts_2 = (Point3D(0, 0), Point3D(0, 2), Point3D(4, 2), Point3D(4, 0))
     plane = Plane(Vector3D(0, 0, 1))
     face_1 = Face3D(pts_1, plane)
     face_2 = Face3D(pts_2, plane)
-    sub_face_height = 2.0
+    sub_face_height = 1.0
     sill_height = 1.0
-    rect_height = 4.0
-    wall_length = 4.0
+    rect_height = 2.0
+    div_dist = 1.0
 
     sub_faces_1 = face_1._sub_faces_by_dimensions(
-        sub_face_height, 6.0, wall_length, 1.0, sill_height, rect_height, None)
+        plane, 2.0, rect_height, sub_face_height, 3.0, sill_height, div_dist)
     assert len(sub_faces_1) == 1
     assert sub_faces_1[0].area == pytest.approx(face_1.area * 0.5, rel=1e-3)
 
     sub_faces_2 = face_2._sub_faces_by_dimensions(
-        sub_face_height, 6.0, wall_length, 1.0, sill_height, rect_height, None)
+        plane, 4.0, rect_height, sub_face_height, 1.0, sill_height, div_dist)
     assert len(sub_faces_2) == 4
     areas = [srf.area for srf in sub_faces_2]
     assert sum(areas) == pytest.approx(face_2.area * 0.5, rel=1e-3)

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -1159,7 +1159,7 @@ def test_sub_faces_by_dimensions():
     sub_faces_1 = face_1._sub_faces_by_dimensions(
         plane, 2.0, rect_height, sub_face_height, 3.0, sill_height, div_dist)
     assert len(sub_faces_1) == 1
-    assert sub_faces_1[0].area == pytest.approx(face_1.area * 0.5, rel=1e-3)
+    assert sub_faces_1[0].area == pytest.approx(face_1.area * 0.49, rel=1e-3)
 
     sub_faces_2 = face_2._sub_faces_by_dimensions(
         plane, 4.0, rect_height, sub_face_height, 1.0, sill_height, div_dist)

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -1142,3 +1142,28 @@ def test_sub_faces_by_ratio():
     assert len(sub_faces_2) == 4
     areas = [srf.area for srf in sub_faces_2]
     assert sum(areas) == pytest.approx(face_2.area * 0.5, rel=1e-3)
+
+
+def test_sub_faces_by_dimensions():
+    """Test the sub_faces_by_dimensions method."""
+    pts_1 = (Point3D(0, 0), Point3D(0, 2), Point3D(2, 2), Point3D(2, 0))
+    pts_2 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 1), Point3D(1, 1),
+             Point3D(1, 2), Point3D(0, 2))
+    plane = Plane(Vector3D(0, 0, 1))
+    face_1 = Face3D(pts_1, plane)
+    face_2 = Face3D(pts_2, plane)
+    window_height = 2
+    sill_height = 1
+    rect_height = 6
+    wall_length = 4
+
+    sub_faces_1 = face_1.sub_faces_by_dimensions(
+        window_height, 6.0, wall_length, 1.0, sill_height, rect_height, None)
+    assert len(sub_faces_1) == 1
+    assert sub_faces_1[0].area == pytest.approx(face_1.area * 0.5, rel=1e-3)
+
+    sub_faces_2 = face_2.sub_faces_by_dimensions(
+        window_height, 6.0, wall_length, 1.0, sill_height, rect_height, None)
+    assert len(sub_faces_2) == 4
+    areas = [srf.area for srf in sub_faces_2]
+    assert sum(areas) == pytest.approx(face_2.area * 0.5, rel=1e-3)

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -1152,10 +1152,10 @@ def test_sub_faces_by_dimensions():
     plane = Plane(Vector3D(0, 0, 1))
     face_1 = Face3D(pts_1, plane)
     face_2 = Face3D(pts_2, plane)
-    sub_face_height = 2
-    sill_height = 1
-    rect_height = 6
-    wall_length = 4
+    sub_face_height = 2.0
+    sill_height = 1.0
+    rect_height = 4.0
+    wall_length = 4.0
 
     sub_faces_1 = face_1._sub_faces_by_dimensions(
         sub_face_height, 6.0, wall_length, 1.0, sill_height, rect_height, None)


### PR DESCRIPTION
Added alternate method on Face3D class to generate rectangular glazing from a base rectangular surface using a height and width, porting original Javascript code to Python. Also added tests to confirm that new Face3D class method is working properly.

Fixes #54  