### PR TITLE
fix(face): Fixed bug in Face3D plane normal

### DIFF
--- a/ladybug_geometry/geometry2d/pointvector.py
+++ b/ladybug_geometry/geometry2d/pointvector.py
@@ -59,10 +59,14 @@ class Vector2D(object):
         """Get the magnitude squared of the vector."""
         return self.x ** 2 + self.y ** 2
     
-    @property
-    def is_zero(self):
-        """Boolean to note whether the vector has a magnitude of zero."""
-        return self.x == 0 and self.y == 0
+    def is_zero(self, tolerance=0):
+        """Boolean to note whether the vector is within a given zero tolerance.
+        
+        Args:
+            tolerance: The tolerance below which the vector is considered to
+                be a zero vector.
+        """
+        return abs(self.x) <= tolerance and abs(self.y) <= tolerance 
 
     def normalize(self):
         """Get a copy of the vector that is a unit vector (magnitude=1)."""

--- a/ladybug_geometry/geometry2d/polygon.py
+++ b/ladybug_geometry/geometry2d/polygon.py
@@ -747,12 +747,12 @@ class Polygon2D(Base2DIn2D):
         # Bounding rectangle check using the Separating Axis Theorem
         polygon1_width = polygon1.max.x - polygon1.min.x
         polygon2_width = polygon2.max.x - polygon2.min.x
-        dist_btwn_x = abs(polygon1.min.x - polygon2.min.x)
+        dist_btwn_x = abs(polygon1.center.x - polygon2.center.x)
         x_gap_btwn_rect = dist_btwn_x - (0.5 * polygon1_width) - (0.5 * polygon2_width)
 
         polygon1_height = polygon1.max.y - polygon1.min.y
         polygon2_height = polygon2.max.y - polygon2.min.y
-        dist_btwn_y = abs(polygon1.min.y - polygon2.min.y)
+        dist_btwn_y = abs(polygon1.center.y - polygon2.center.y)
         y_gap_btwn_rect = dist_btwn_y - (0.5 * polygon1_height) - (0.5 * polygon2_height)
 
         if x_gap_btwn_rect > tolerance or y_gap_btwn_rect > tolerance:

--- a/ladybug_geometry/geometry3d/pointvector.py
+++ b/ladybug_geometry/geometry3d/pointvector.py
@@ -69,10 +69,15 @@ class Vector3D(object):
         """Get the magnitude squared of the vector."""
         return self.x ** 2 + self.y ** 2 + self.z ** 2
     
-    @property
-    def is_zero(self):
-        """Boolean to note whether the vector has a magnitude of zero."""
-        return self.x == 0 and self.y == 0 and self.z == 0
+    def is_zero(self, tolerance=0):
+        """Boolean to note whether the vector is within a given zero tolerance.
+        
+        Args:
+            tolerance: The tolerance below which the vector is considered to
+                be a zero vector.
+        """
+        return abs(self.x) <= tolerance and abs(self.y) <= tolerance and \
+            abs(self.z) <= tolerance
 
     def normalize(self):
         """Get a copy of the vector that is a unit vector (magnitude=1)."""

--- a/ladybug_geometry/geometry3d/polyface.py
+++ b/ladybug_geometry/geometry3d/polyface.py
@@ -209,9 +209,11 @@ class Polyface3D(Base2DIn3D):
         polyface = cls(_verts, _face_indices, {'edge_indices': _edge_indices,
                                                'edge_types': [1] * 12})
         verts = tuple(tuple(_verts[i] for i in face[0]) for face in _face_indices)
-        bottom = Face3D(verts[0], plane=base_plane.flip(), enforce_right_hand=False)
+        bottom = Face3D(verts[0], plane_or_tolerance=base_plane.flip(),
+                        enforce_right_hand=False)
         middle = tuple(Face3D(v, enforce_right_hand=False) for v in verts[1:5])
-        top = Face3D(verts[5], plane=base_plane.move(_h_vec), enforce_right_hand=False)
+        top = Face3D(verts[5], plane_or_tolerance=base_plane.move(_h_vec),
+                     enforce_right_hand=False)
         polyface._faces = (bottom,) + middle + (top,)
         polyface._volume = width * depth * height
         return polyface
@@ -698,17 +700,17 @@ class Polyface3D(Base2DIn3D):
         # Bounding box check using the Separating Axis Theorem
         polyf1_width = polyface1.max.x - polyface1.min.x
         polyf2_width = polyface2.max.x - polyface2.min.x
-        dist_btwn_x = abs(polyface1.min.x - polyface2.min.x)
+        dist_btwn_x = abs(polyface1.center.x - polyface2.center.x)
         x_gap_btwn_box = dist_btwn_x - (0.5 * polyf1_width) - (0.5 * polyf2_width)
 
         polyf1_depth = polyface1.max.y - polyface1.min.y
         polyf2_depth = polyface2.max.y - polyface2.min.y
-        dist_btwn_y = abs(polyface1.min.y - polyface2.min.y)
+        dist_btwn_y = abs(polyface1.center.y - polyface2.center.y)
         y_gap_btwn_box = dist_btwn_y - (0.5 * polyf1_depth) - (0.5 * polyf2_depth)
 
         polyf1_height = polyface1.max.z - polyface1.min.z
         polyf2_height = polyface2.max.z - polyface2.min.z
-        dist_btwn_z = abs(polyface1.min.z - polyface2.min.z)
+        dist_btwn_z = abs(polyface1.center.z - polyface2.center.z)
         z_gap_btwn_box = dist_btwn_z - (0.5 * polyf1_height) - (0.5 * polyf2_height)
 
         if x_gap_btwn_box > tolerance or y_gap_btwn_box > tolerance or \

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -56,7 +56,7 @@ def test_face3d_to_from_dict():
 
     bound_pts = [Point3D(0, 0), Point3D(4, 0), Point3D(4, 4), Point3D(0, 4)]
     hole_pts = [Point3D(1, 1), Point3D(3, 1), Point3D(3, 3), Point3D(1, 3)]
-    face = Face3D(bound_pts, None, [hole_pts])
+    face = Face3D(bound_pts, 0, [hole_pts])
     face_dict = face.to_dict()
     new_face = Face3D.from_dict(face_dict)
     assert isinstance(new_face, Face3D)
@@ -101,7 +101,7 @@ def test_face3d_init_from_vertices_colinear():
            Point3D(2, 0, 2))
     face = Face3D(pts)
 
-    assert not face.normal.is_zero
+    assert not face.normal.is_zero()
     assert face.plane.n == Vector3D(0, 0, -1)
     assert face.plane.n == face.normal
     assert face.plane.o == Point3D(0, 0, 2)
@@ -209,7 +209,7 @@ def test_face3d_init_from_shape_with_hole():
     """Test the initalization of Face3D from_shape_with_holes with one hole."""
     bound_pts = [Point3D(0, 0), Point3D(4, 0), Point3D(4, 4), Point3D(0, 4)]
     hole_pts = [Point3D(1, 1), Point3D(3, 1), Point3D(3, 3), Point3D(1, 3)]
-    face = Face3D(bound_pts, None, [hole_pts])
+    face = Face3D(bound_pts, 0, [hole_pts])
 
     assert face.plane.n == Vector3D(0, 0, 1)
     assert face.plane.n == face.normal
@@ -243,7 +243,7 @@ def test_face3d_init_from_shape_with_holes():
     bound_pts = [Point3D(0, 0), Point3D(4, 0), Point3D(4, 4), Point3D(0, 4)]
     hole_pts_1 = [Point3D(1, 1), Point3D(1.5, 1), Point3D(1.5, 1.5), Point3D(1, 1.5)]
     hole_pts_2 = [Point3D(2, 2), Point3D(3, 2), Point3D(3, 3), Point3D(2, 3)]
-    face = Face3D(bound_pts, None, [hole_pts_1, hole_pts_2])
+    face = Face3D(bound_pts, 0, [hole_pts_1, hole_pts_2])
 
     assert face.plane.n == Vector3D(0, 0, 1)
     assert face.plane.n == face.normal
@@ -275,7 +275,7 @@ def test_face3d_init_from_punched_geometry():
     hole_pts_1 = [Point3D(1, 1), Point3D(1.5, 1), Point3D(1.5, 1.5), Point3D(1, 1.5)]
     hole_pts_2 = [Point3D(2, 2), Point3D(3, 2), Point3D(3, 3), Point3D(2, 3)]
     face_1 = Face3D(bound_pts)
-    face_2 = Face3D(bound_pts, None, [hole_pts_1])
+    face_2 = Face3D(bound_pts, 0, [hole_pts_1])
     sub_face = Face3D(hole_pts_2)
 
     face = Face3D.from_punched_geometry(face_1, [sub_face])

--- a/tests/pointvector2d_test.py
+++ b/tests/pointvector2d_test.py
@@ -17,6 +17,7 @@ def test_vector2_init():
     assert vec[1] == 2
     assert vec.magnitude == 2
     assert vec.magnitude_squared == 4
+    assert not vec.is_zero()
 
     assert len(vec) == 2
     pt_tuple = tuple(i for i in vec)
@@ -32,6 +33,7 @@ def test_zero_magnitude_vector():
     """Test properties with a zero magnitude vecotr."""
     vec = Vector2D(0, 0)
 
+    assert vec.is_zero()
     assert vec.magnitude == 0
     assert vec.normalize() == vec
 

--- a/tests/pointvector3d_test.py
+++ b/tests/pointvector3d_test.py
@@ -19,6 +19,7 @@ def test_vector3_init():
     assert vec[2] == 0
     assert vec.magnitude == 2
     assert vec.magnitude_squared == 4
+    assert not vec.is_zero()
 
     assert len(vec) == 3
     pt_tuple = tuple(i for i in vec)
@@ -49,6 +50,7 @@ def test_zero_magnitude_vector():
     """Test properties with a zero magnitude vecotr."""
     vec = Vector3D(0, 0, 0)
 
+    assert vec.is_zero()
     assert vec.magnitude == 0
     assert vec.normalize() == vec
 

--- a/tests/polyface3d_test.py
+++ b/tests/polyface3d_test.py
@@ -312,7 +312,7 @@ def test_polyface3d_init_from_offset_face_hole():
     """Test the initalization of Poyface3D from_offset_face for a face witha hole."""
     bound_pts = [Point3D(0, 0), Point3D(3, 0), Point3D(3, 3), Point3D(0, 3)]
     hole_pts = [Point3D(1, 1), Point3D(2, 1), Point3D(2, 2), Point3D(1, 2)]
-    face = Face3D(bound_pts, None, [hole_pts])
+    face = Face3D(bound_pts, 0, [hole_pts])
 
     polyface = Polyface3D.from_offset_face(face, 1)
 
@@ -363,7 +363,7 @@ def test_polyface3d_to_from_dict_hole():
     """Test the to/from dict of Polyface3D objects with a hole."""
     bound_pts = [Point3D(0, 0), Point3D(3, 0), Point3D(3, 3), Point3D(0, 3)]
     hole_pts = [Point3D(1, 1), Point3D(2, 1), Point3D(2, 2), Point3D(1, 2)]
-    face = Face3D(bound_pts, None, [hole_pts])
+    face = Face3D(bound_pts, 0, [hole_pts])
     polyface = Polyface3D.from_offset_face(face, 1)
 
     polyface_dict = polyface.to_dict()


### PR DESCRIPTION
Without a tolerance input for the Face3D plane auto-calculation, the plane normal was completely incorrect in some cases where the planarity of the Face3D differed by a small amount. This commit should fix this by exposing an option to input a tolerance when the input Plane is None.

This bug is really critical, @mostaphaRoudsari , and I want to find out which of the other libraries are affected by it as soon as I can so I am just going to merge it in.