### PR TITLE
fix(line): Fix bug in LineSegment.subdivide_evenly method

### DIFF
--- a/ladybug_geometry/geometry2d/line.py
+++ b/ladybug_geometry/geometry2d/line.py
@@ -142,13 +142,14 @@ class LineSegment2D(Base1DIn2D):
         Args:
             number: The number of segments into which the line will be divided.
         """
-        interval = 1 / number
+        interval = 1 / number  # can create tolerance issue where interval * number < 1
         parameter = interval
         sub_pts = [self.p]
         while parameter < 1:
             sub_pts.append(self.point_at(parameter))
             parameter += interval
-        sub_pts.append(self.p2)
+        if len(sub_pts) != number + 1:  # avoid tolerance issue from interval division
+            sub_pts.append(self.p2)
         return sub_pts
 
     def point_at(self, parameter):

--- a/ladybug_geometry/geometry3d/line.py
+++ b/ladybug_geometry/geometry3d/line.py
@@ -172,15 +172,17 @@ class LineSegment3D(Base1DIn3D):
         """Get Point3D values along the line that divide it into evenly-spaced segments.
 
         Args:
-            number: The number of segments into which the line will be divided.
+            number: Integer for the number of segments into which the line will
+                be divided.
         """
-        interval = 1 / number
+        interval = 1 / number  # can create tolerance issue where interval * number < 1
         parameter = interval
         sub_pts = [self.p]
         while parameter < 1:
             sub_pts.append(self.point_at(parameter))
             parameter += interval
-        sub_pts.append(self.p2)
+        if len(sub_pts) != number + 1:  # avoid tolerance issue from interval division
+            sub_pts.append(self.p2)
         return sub_pts
 
     def point_at(self, parameter):

--- a/tests/line3d_test.py
+++ b/tests/line3d_test.py
@@ -261,6 +261,19 @@ def test_subdivide():
     assert divisions[4] == Point3D(2, 4, 2)
 
 
+def test_subdivide_tolerance_issue():
+    """Test the LineSegment3D subdivide method handles Python tolerance.
+
+    This case was taken from an originally failing situation in Rhino.
+    """
+    origin = Point3D(-68.773857131759087, 20.836167334772536, 18.897600000000001)
+    dir = Vector3D(-0.026879795220556984, -0.99963867302585929, 0.0)
+    bottom_seg = LineSegment3D.from_sdl(origin, dir, 21.5037894118)
+
+    assert len(bottom_seg.subdivide_evenly(5)) == 6
+    assert len(bottom_seg.subdivide_evenly(7)) == 8
+
+
 def test_closest_point():
     """Test the LineSegment3D closest_point method."""
     pt = Point3D(2, 2, 2)


### PR DESCRIPTION
This commit fixes a Python tolerance issue that can sometimes arise in the LineSegment.subdivide_evenly method. I was only able to find this one after testing it on several thousand line segments in Rhino. Glad that this bug is squashed!