### PR TITLE
feat(hash): Add __hash__ methods that agree with __eq__ to all objects

### DIFF
--- a/ladybug_geometry/_mesh.py
+++ b/ladybug_geometry/_mesh.py
@@ -331,13 +331,30 @@ class MeshBase(object):
         return vertices, face_collector
 
     def __len__(self):
-        return len(self.vertices)
+        return len(self._vertices)
 
     def __getitem__(self, key):
-        return self.vertices[key]
+        return self._vertices[key]
 
     def __iter__(self):
-        return iter(self.vertices)
+        return iter(self._vertices)
+
+    def __copy__(self):
+        return MeshBase(self._vertices, self._faces, self._colors)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return tuple(hash(pt) for pt in self._vertices) + \
+            tuple(hash(face) for face in self._faces)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, MeshBase) and self.__key() == other.__key()
+    
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def ToString(self):
         """Overwrite .NET ToString."""

--- a/ladybug_geometry/geometry2d/_1d.py
+++ b/ladybug_geometry/geometry2d/_1d.py
@@ -101,6 +101,19 @@ class Base1DIn2D(object):
     def __copy__(self):
         return self.__class__(self.p, self.v)
 
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (hash(self.p), hash(self.v))
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Base1DIn2D) and self.__key() == other.__key()
+    
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def ToString(self):
         """Overwrite .NET ToString."""
         return self.__repr__()

--- a/ladybug_geometry/geometry2d/_2d.py
+++ b/ladybug_geometry/geometry2d/_2d.py
@@ -88,16 +88,29 @@ class Base2DIn2D(object):
         return vertices
 
     def __len__(self):
-        return len(self.vertices)
+        return len(self._vertices)
 
     def __getitem__(self, key):
-        return self.vertices[key]
+        return self._vertices[key]
 
     def __iter__(self):
-        return iter(self.vertices)
+        return iter(self._vertices)
 
     def __copy__(self):
         return Base2DIn2D(self._vertices)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return tuple(hash(pt) for pt in self._vertices)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Base2DIn2D) and self.__key() == other.__key()
+    
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def ToString(self):
         """Overwrite .NET ToString."""

--- a/ladybug_geometry/geometry2d/arc.py
+++ b/ladybug_geometry/geometry2d/arc.py
@@ -397,7 +397,20 @@ class Arc2D(object):
         return _diff if not angle < self.a1 else 2 * math.pi + _diff
 
     def __copy__(self):
-        return self.__class__(self.c, self.r, self.a1, self.a2)
+        return Arc2D(self.c, self.r, self.a1, self.a2)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self.c, self.r, self.a1, self.a2)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Arc2D) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def ToString(self):
         """Overwrite .NET ToString."""

--- a/ladybug_geometry/geometry2d/line.py
+++ b/ladybug_geometry/geometry2d/line.py
@@ -212,11 +212,18 @@ class LineSegment2D(Base1DIn2D):
     def __abs__(self):
         return abs(self.v)
 
+    def __copy__(self):
+        return LineSegment2D(self.p, self.v)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (hash(self.p), hash(self.v))
+
+    def __hash__(self):
+        return hash(self.__key())
+
     def __eq__(self, other):
-        if isinstance(other, LineSegment2D):
-            return self.p == other.p and self.v == other.v
-        else:
-            return False
+        return isinstance(other, LineSegment2D) and self.__key() == other.__key()
 
     def __repr__(self):
         return 'LineSegment2D (<%.2f, %.2f> to <%.2f, %.2f>)' % \

--- a/ladybug_geometry/geometry2d/mesh.py
+++ b/ladybug_geometry/geometry2d/mesh.py
@@ -605,6 +605,17 @@ class Mesh2D(MeshBase):
         _new_mesh._centroid = self._centroid
         return _new_mesh
 
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return tuple(hash(pt) for pt in self._vertices) + \
+            tuple(hash(face) for face in self._faces)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Mesh2D) and self.__key() == other.__key()
+
     def __repr__(self):
         return 'Ladybug Mesh2D ({} faces) ({} vertices)'.format(
             len(self.faces), len(self))

--- a/ladybug_geometry/geometry2d/pointvector.py
+++ b/ladybug_geometry/geometry2d/pointvector.py
@@ -187,11 +187,16 @@ class Vector2D(object):
     def __copy__(self):
         return self.__class__(self.x, self.y)
 
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self.x, self.y)
+
+    def __hash__(self):
+        return hash(self.__key())
+
     def __eq__(self, other):
-        if isinstance(other, (Vector2D, Point2D)):
-            return self.x == other.x and self.y == other.y
-        else:
-            return False
+        return isinstance(other, (Vector2D, Point2D)) and \
+            self.__key() == other.__key()
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/ladybug_geometry/geometry2d/polygon.py
+++ b/ladybug_geometry/geometry2d/polygon.py
@@ -831,8 +831,17 @@ class Polygon2D(Base2DIn2D):
         return _a < 0
 
     def __copy__(self):
-        _new_poly = Polygon2D(self.vertices)
-        return _new_poly
+        return Polygon2D(self._vertices)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return tuple(hash(pt) for pt in self._vertices)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Polygon2D) and self.__key() == other.__key()
 
     def __repr__(self):
         return 'Polygon2D ({} vertices)'.format(len(self))

--- a/ladybug_geometry/geometry2d/ray.py
+++ b/ladybug_geometry/geometry2d/ray.py
@@ -77,14 +77,15 @@ class Ray2D(Base1DIn2D):
     def _u_in(self, u):
         return u >= 0.0
 
-    def __eq__(self, other):
-        if isinstance(other, Ray2D):
-            return self.p == other.p and self.v == other.v
-        else:
-            return False
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (hash(self.p), hash(self.v))
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Ray2D) and self.__key() == other.__key()
 
     def __repr__(self):
         return 'Ray2D (point <%.2f, %.2f>) (vector <%.2f, %.2f>)' % \

--- a/ladybug_geometry/geometry3d/_1d.py
+++ b/ladybug_geometry/geometry3d/_1d.py
@@ -125,6 +125,19 @@ class Base1DIn3D(object):
 
     def __copy__(self):
         return self.__class__(self.p, self.v)
+    
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (hash(self.p), hash(self.v))
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Base1DIn3D) and self.__key() == other.__key()
+    
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def ToString(self):
         """Overwrite .NET ToString."""

--- a/ladybug_geometry/geometry3d/_2d.py
+++ b/ladybug_geometry/geometry3d/_2d.py
@@ -93,16 +93,29 @@ class Base2DIn3D(object):
         return vertices
 
     def __len__(self):
-        return len(self.vertices)
+        return len(self._vertices)
 
     def __getitem__(self, key):
-        return self.vertices[key]
+        return self._vertices[key]
 
     def __iter__(self):
-        return iter(self.vertices)
+        return iter(self._vertices)
 
     def __copy__(self):
         return Base2DIn3D(self._vertices)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return tuple(hash(pt) for pt in self._vertices)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Base2DIn3D) and self.__key() == other.__key()
+    
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def ToString(self):
         """Overwrite .NET ToString."""

--- a/ladybug_geometry/geometry3d/arc.py
+++ b/ladybug_geometry/geometry3d/arc.py
@@ -324,7 +324,20 @@ class Arc3D(object):
         return Plane(n, pt1)
 
     def __copy__(self):
-        return self.__class__(self.plane, self.radius, self.a1, self.a2)
+        return Arc3D(self.plane, self.radius, self.a1, self.a2)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (hash(self.plane), self.radius, self.a1, self.a2)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Arc3D) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def ToString(self):
         """Overwrite .NET ToString."""

--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -1730,6 +1730,16 @@ class Face3D(Base2DIn3D):
         _new_face._mesh2d = self._mesh2d
         _new_face._mesh3d = self._mesh3d
         return _new_face
+    
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return tuple(hash(pt) for pt in self._vertices) + (hash(self._plane),)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Face3D) and self.__key() == other.__key()
 
     def __repr__(self):
         return 'Face3D ({} vertices)'.format(len(self))

--- a/ladybug_geometry/geometry3d/line.py
+++ b/ladybug_geometry/geometry3d/line.py
@@ -212,12 +212,19 @@ class LineSegment3D(Base1DIn3D):
 
     def __abs__(self):
         return abs(self.v)
+    
+    def __copy__(self):
+        return LineSegment3D(self.p, self.v)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (hash(self.p), hash(self.v))
+
+    def __hash__(self):
+        return hash(self.__key())
 
     def __eq__(self, other):
-        if isinstance(other, LineSegment3D):
-            return self.p == other.p and self.v == other.v
-        else:
-            return False
+        return isinstance(other, LineSegment3D) and self.__key() == other.__key()
 
     def __repr__(self):
         return 'LineSegment3D (<%.2f, %.2f, %.2f> to <%.2f, %.2f, %.2f>)' % \

--- a/ladybug_geometry/geometry3d/mesh.py
+++ b/ladybug_geometry/geometry3d/mesh.py
@@ -553,6 +553,17 @@ class Mesh3D(MeshBase):
         _new_mesh._vertex_normals = self._vertex_normals
         return _new_mesh
 
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return tuple(hash(pt) for pt in self._vertices) + \
+            tuple(hash(face) for face in self._faces)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Mesh3D) and self.__key() == other.__key()
+
     def __repr__(self):
         return 'Mesh3D ({} faces) ({} vertices)'.format(
             len(self.faces), len(self))

--- a/ladybug_geometry/geometry3d/plane.py
+++ b/ladybug_geometry/geometry3d/plane.py
@@ -361,13 +361,20 @@ class Plane(object):
                 'x': self.x.to_array()}
 
     def __copy__(self):
-        return self.__class__(self.n, self.o)
+        return Plane(self.n, self.o, self.x)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self.n, self.o, self.x)
+
+    def __hash__(self):
+        return hash(self.__key())
 
     def __eq__(self, other):
-        if isinstance(other, Plane):
-            return self.n == other.n and self.o == other.o and self.x == other.x
-        else:
-            return False
+        return isinstance(other, Plane) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def ToString(self):
         """Overwrite .NET ToString."""

--- a/ladybug_geometry/geometry3d/pointvector.py
+++ b/ladybug_geometry/geometry3d/pointvector.py
@@ -203,12 +203,17 @@ class Vector3D(object):
 
     def __copy__(self):
         return self.__class__(self.x, self.y, self.z)
+    
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self.x, self.y, self.z)
+
+    def __hash__(self):
+        return hash(self.__key())
 
     def __eq__(self, other):
-        if isinstance(other, (Vector3D, Point3D)):
-            return self.x == other.x and self.y == other.y and self.z == other.z
-        else:
-            return False
+        return isinstance(other, (Vector3D, Point3D)) and \
+            self.__key() == other.__key()
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/ladybug_geometry/geometry3d/polyface.py
+++ b/ladybug_geometry/geometry3d/polyface.py
@@ -33,14 +33,13 @@ class Polyface3D(Base2DIn3D):
             should be formatted as a dictionary with two keys as follows:
 
             *   'edge_indices':
-                A list of tuple objects that each contain two integers.
+                An array objects that each contain two integers.
                 These integers correspond to indices within the vertices list and
                 each tuple represents a line sengment for an edge of the polyface.
             *   'edge_types':
-                A list of integers for each edge that parallels
-                the edge_indices list. An integer of 0 denotes a naked edge, an
-                integer of 1 denotes an internal edge. Anything higher is a
-                non-manifold edge.
+                An array of integers for each edge that parallels the edge_indices
+                list. An integer of 0 denotes a naked edge, an integer of 1
+                denotes an internal edge. Anything higher is a non-manifold edge.
 
     Properties:
         * vertices
@@ -807,6 +806,17 @@ class Polyface3D(Base2DIn3D):
         _new_poly = Polyface3D(self.vertices, self.face_indices, self.edge_information)
         _new_poly._faces = self._faces
         return _new_poly
+    
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return tuple(hash(pt) for pt in self._vertices) + \
+            tuple(hash(face) for face in self._face_indices)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Polyface3D) and self.__key() == other.__key()
 
     def __repr__(self):
         return 'Polyface3D ({} faces) ({} vertices)'.format(

--- a/ladybug_geometry/geometry3d/ray.py
+++ b/ladybug_geometry/geometry3d/ray.py
@@ -98,15 +98,19 @@ class Ray3D(Base1DIn3D):
 
     def _u_in(self, u):
         return u >= 0.0
+    
+    def __copy__(self):
+        return Ray3D(self.p, self.v)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (hash(self.p), hash(self.v))
+
+    def __hash__(self):
+        return hash(self.__key())
 
     def __eq__(self, other):
-        if isinstance(other, Ray3D):
-            return self.p == other.p and self.v == other.v
-        else:
-            return False
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
+        return isinstance(other, Ray3D) and self.__key() == other.__key()
 
     def __repr__(self):
         return 'Ray3D (point <%.2f, %.2f, %.2f>) (vector <%.2f, %.2f, %.2f>)' % \

--- a/ladybug_geometry/geometry3d/sphere.py
+++ b/ladybug_geometry/geometry3d/sphere.py
@@ -187,11 +187,25 @@ class Sphere3D(object):
 
     def to_dict(self):
         """Get Sphere as a dictionary."""
-        return {'type': 'Sphere3D', 'center': self.center.to_array(),
+        return {'type': 'Sphere3D',
+                'center': self.center.to_array(),
                 'radius': self.radius}
 
     def __copy__(self):
-        return Sphere3D(self.center, self.radius)
+        return Sphere3D(self._center, self._radius)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self._center, self._radius)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Sphere3D) and self.__key() == other.__key()
+    
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def ToString(self):
         """Overwrite .NET ToString."""

--- a/tests/arc2d_test.py
+++ b/tests/arc2d_test.py
@@ -146,6 +146,21 @@ def test_arc2_to_from_dict():
     assert new_arc.to_dict() == arc_dict
 
 
+def test_equality():
+    """Test the equality of Arc2D objects."""
+    pt = Point2D(2, 0)
+    arc = Arc2D(pt, 1, 0, math.pi)
+    arc_dup = arc.duplicate()
+    arc_alt = Arc2D(pt, 1, 0.1, math.pi)
+
+    assert arc is arc
+    assert arc is not arc_dup
+    assert arc == arc_dup
+    assert hash(arc) == hash(arc_dup)
+    assert arc != arc_alt
+    assert hash(arc) != hash(arc_alt)
+
+
 def test_move():
     """Test the Arc2D move method."""
     pt = Point2D(2, 0)

--- a/tests/arc3d_test.py
+++ b/tests/arc3d_test.py
@@ -153,6 +153,21 @@ def test_arc3_to_from_dict():
     assert new_arc.to_dict() == arc_dict
 
 
+def test_equality():
+    """Test the equality of Arc3D objects."""
+    pt = Point3D(2, 0, 2)
+    arc = Arc3D(Plane(o=pt), 1, 0, math.pi)
+    arc_dup = arc.duplicate()
+    arc_alt = Arc3D(Plane(o=Point3D(2, 0.1, 2)), 1, 0.1, math.pi)
+
+    assert arc is arc
+    assert arc is not arc_dup
+    assert arc == arc_dup
+    assert hash(arc) == hash(arc_dup)
+    assert arc != arc_alt
+    assert hash(arc) != hash(arc_alt)
+
+
 def test_move():
     """Test the Arc3D move method."""
     pt = Point3D(2, 0, 0)

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -45,6 +45,23 @@ def test_face3d_init():
     assert face.vertices[0] == face[0]
 
 
+def test_equality():
+    """Test the equality of Face3D objects."""
+    pts = (Point3D(0, 0, 2), Point3D(0, 2, 2), Point3D(2, 2, 2), Point3D(2, 0, 2))
+    pts_2 = (Point3D(0.1, 0, 2), Point3D(0, 2, 2), Point3D(2, 2, 2), Point3D(2, 0, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    face = Face3D(pts, plane)
+    face_dup = face.duplicate()
+    face_alt = Face3D(pts_2, plane)
+
+    assert face is face
+    assert face is not face_dup
+    assert face == face_dup
+    assert hash(face) == hash(face_dup)
+    assert face != face_alt
+    assert hash(face) != hash(face_alt)
+
+
 def test_face3d_to_from_dict():
     """Test the to/from dict of Face3D objects."""
     pts = (Point3D(0, 0, 2), Point3D(0, 2, 2), Point3D(2, 2, 2), Point3D(2, 0, 2))

--- a/tests/line2d_test.py
+++ b/tests/line2d_test.py
@@ -65,8 +65,8 @@ def test_init_from_sdl():
     assert seg.length == 2
 
 
-def test_linesegment2_mutability():
-    """Test the mutability and immutability of LineSegement2D objects."""
+def test_linesegment2_immutability():
+    """Test the immutability of LineSegement2D objects."""
     pt = Point2D(2, 0)
     vec = Vector2D(0, 2)
     seg = LineSegment2D(pt, vec)
@@ -84,6 +84,22 @@ def test_linesegment2_mutability():
     seg_copy = seg.duplicate()
     assert seg.p == seg_copy.p
     assert seg.v == seg_copy.v
+
+
+def test_equality():
+    """Test the equality of LineSegement2D objects."""
+    pt = Point2D(2, 0)
+    vec = Vector2D(0, 2)
+    seg = LineSegment2D(pt, vec)
+    seg_dup = seg.duplicate()
+    seg_alt = LineSegment2D(Point2D(2, 0.1), vec)
+
+    assert seg is seg
+    assert seg is not seg_dup
+    assert seg == seg_dup
+    assert hash(seg) == hash(seg_dup)
+    assert seg != seg_alt
+    assert hash(seg) != hash(seg_alt)
 
 
 def test_move():

--- a/tests/line3d_test.py
+++ b/tests/line3d_test.py
@@ -28,6 +28,22 @@ def test_linesegment3d_init():
     assert flip_seg.v == Vector3D(0, -2, 0)
 
 
+def test_equality():
+    """Test the equality of LineSegement3D objects."""
+    pt = Point3D(2, 0, 2)
+    vec = Vector3D(0, 2, 0)
+    seg = LineSegment3D(pt, vec)
+    seg_dup = seg.duplicate()
+    seg_alt = LineSegment3D(Point3D(2, 0.1, 2), vec)
+
+    assert seg is seg
+    assert seg is not seg_dup
+    assert seg == seg_dup
+    assert hash(seg) == hash(seg_dup)
+    assert seg != seg_alt
+    assert hash(seg) != hash(seg_alt)
+
+
 def test_linesegment3_to_from_dict():
     """Test the to/from dict of LineSegment3D objects."""
     pt = Point3D(2, 0, 2)
@@ -65,8 +81,8 @@ def test_init_from_sdl():
     assert seg.length == 2
 
 
-def test_linesegment3d_mutability():
-    """Test the mutability and immutability of LineSegment3D objects."""
+def test_linesegment3d_immutability():
+    """Test the immutability of LineSegment3D objects."""
     pt = Point3D(2, 0, 0)
     vec = Vector3D(0, 2, 0)
     seg = LineSegment3D(pt, vec)

--- a/tests/mesh2d_test.py
+++ b/tests/mesh2d_test.py
@@ -40,6 +40,22 @@ def test_mesh2d_init():
         assert len(vf) == 1
 
 
+def test_equality():
+    """Test the equality of Polygon2D objects."""
+    pts = (Point2D(0, 0), Point2D(0, 2), Point2D(2, 2), Point2D(2, 0))
+    pts_2 = (Point2D(0, 0), Point2D(0, 2), Point2D(2, 2), Point2D(2, 0.1))
+    mesh = Mesh2D(pts, [(0, 1, 2, 3)])
+    mesh_dup = mesh.duplicate()
+    mesh_alt = Mesh2D(pts_2, [(0, 1, 2, 3)])
+
+    assert mesh is mesh
+    assert mesh is not mesh_dup
+    assert mesh == mesh_dup
+    assert hash(mesh) == hash(mesh_dup)
+    assert mesh != mesh_alt
+    assert hash(mesh) != hash(mesh_alt)
+
+
 def test_mesh2d_to_from_dict():
     """Test the to/from dict of Mesh2D objects."""
     pts = (Point2D(0, 0), Point2D(0, 2), Point2D(2, 2), Point2D(2, 0))

--- a/tests/mesh3d_test.py
+++ b/tests/mesh3d_test.py
@@ -39,6 +39,22 @@ def test_mesh3d_init():
         assert len(vf) == 1
 
 
+def test_equality():
+    """Test the equality of Mesh3D objects."""
+    pts = (Point3D(0, 0, 2), Point3D(0, 2, 2), Point3D(2, 2, 2), Point3D(2, 0, 2))
+    pts_2 = (Point3D(0.1, 0, 2), Point3D(0, 2, 2), Point3D(2, 2, 2), Point3D(2, 0, 2))
+    mesh = Mesh3D(pts, [(0, 1, 2, 3)])
+    mesh_dup = mesh.duplicate()
+    mesh_alt = Mesh3D(pts_2, [(0, 1, 2, 3)])
+
+    assert mesh is mesh
+    assert mesh is not mesh_dup
+    assert mesh == mesh_dup
+    assert hash(mesh) == hash(mesh_dup)
+    assert mesh != mesh_alt
+    assert hash(mesh) != hash(mesh_alt)
+
+
 def test_mesh3d_to_from_dict():
     """Test the to/from dict of Mesh3D objects."""
     pts = (Point3D(0, 0), Point3D(0, 2), Point3D(2, 2), Point3D(2, 0))

--- a/tests/plane_test.py
+++ b/tests/plane_test.py
@@ -40,6 +40,22 @@ def test_plane_init():
     assert plane_flip.k == 0
 
 
+def test_equality():
+    """Test the equality of Plane objects."""
+    pt = Point3D(2, 0, 2)
+    vec = Vector3D(0, 2, 0)
+    plane = Plane(vec, pt)
+    plane_dup = plane.duplicate()
+    plane_alt = Plane(vec, Point3D(2, 0.1, 2))
+
+    assert plane is plane
+    assert plane is not plane_dup
+    assert plane == plane_dup
+    assert hash(plane) == hash(plane_dup)
+    assert plane != plane_alt
+    assert hash(plane) != hash(plane_alt)
+
+
 def test_plane_to_from_dict():
     """Test the initalization of Plane objects and basic properties."""
     pt = Point3D(2, 0, 2)

--- a/tests/pointvector2d_test.py
+++ b/tests/pointvector2d_test.py
@@ -63,8 +63,22 @@ def test_distance_to_point():
     assert pt_1.distance_to_point(pt_2) == 2
 
 
+def test_equality():
+    """Test the equality of Point2D objects."""
+    pt_1 = Point2D(0, 2)
+    pt_1_dup = pt_1.duplicate()
+    pt_1_alt = Point2D(0.1, 2)
+
+    assert pt_1 is pt_1
+    assert pt_1 is not pt_1_dup
+    assert pt_1 == pt_1_dup
+    assert hash(pt_1) == hash(pt_1_dup)
+    assert pt_1 != pt_1_alt
+    assert hash(pt_1) != hash(pt_1_alt)
+
+
 def test_is_equivalent():
-    """Test the is_equivalent method."""
+    """Test the is_equivalent method using tolerances."""
     pt_1 = Point2D(0, 2)
     pt_2 = Point2D(0.00001, 2)
     pt_3 = Point2D(0, 1)

--- a/tests/pointvector3d_test.py
+++ b/tests/pointvector3d_test.py
@@ -31,6 +31,20 @@ def test_vector3_init():
     assert norm_vec.magnitude == 1
 
 
+def test_equality():
+    """Test the equality of Point3D objects."""
+    pt_1 = Point3D(0, 2, 1)
+    pt_1_dup = pt_1.duplicate()
+    pt_1_alt = Point3D(0.1, 2, 1)
+
+    assert pt_1 is pt_1
+    assert pt_1 is not pt_1_dup
+    assert pt_1 == pt_1_dup
+    assert hash(pt_1) == hash(pt_1_dup)
+    assert pt_1 != pt_1_alt
+    assert hash(pt_1) != hash(pt_1_alt)
+
+
 def test_vector3_to_from_dict():
     """Test the initalization of Vector3D objects and basic properties."""
     vec = Vector3D(0, 2, 0)

--- a/tests/polyface3d_test.py
+++ b/tests/polyface3d_test.py
@@ -42,6 +42,26 @@ def test_polyface3d_init_solid():
     assert polyface.faces[5].normal == Vector3D(0, 0, 1)
 
 
+def test_equality():
+    """Test the equality of Polyface3D objects."""
+    pts = [Point3D(0, 0, 0), Point3D(0, 2, 0), Point3D(2, 2, 0), Point3D(2, 0, 0),
+           Point3D(0, 0, 2), Point3D(0, 2, 2), Point3D(2, 2, 2), Point3D(2, 0, 2)]
+    face_indices = [[(0, 1, 2, 3)], [(0, 4, 5, 1)], [(0, 3, 7, 4)],
+                    [(2, 1, 5, 6)], [(2, 3, 7, 6)], [(4, 5, 6, 7)]]
+    face_indices_2 = [[(0, 1, 2, 3)], [(0, 4, 5, 1)], [(0, 3, 7, 4)],
+                      [(2, 1, 5, 6)], [(2, 3, 7, 6)]]
+    polyface = Polyface3D(pts, face_indices)
+    polyface_dup = polyface.duplicate()
+    polyface_alt = Polyface3D(pts, face_indices_2)
+
+    assert polyface is polyface
+    assert polyface is not polyface_dup
+    assert polyface == polyface_dup
+    assert hash(polyface) == hash(polyface_dup)
+    assert polyface != polyface_alt
+    assert hash(polyface) != hash(polyface_alt)
+
+
 def test_polyface3d_init_open():
     """Test the initalization of Poyface3D and basic properties of open objects."""
     pts = [Point3D(0, 0, 0), Point3D(0, 2, 0), Point3D(2, 2, 0), Point3D(2, 0, 0),

--- a/tests/polygon2d_test.py
+++ b/tests/polygon2d_test.py
@@ -37,6 +37,22 @@ def test_polygon2d_init():
     assert polygon.vertices[0] == polygon[0]
 
 
+def test_equality():
+    """Test the equality of Polygon2D objects."""
+    pts = (Point2D(0, 0), Point2D(2, 0), Point2D(2, 2), Point2D(0, 2))
+    pts_2 = (Point2D(0, 0), Point2D(2, 0), Point2D(2, 2), Point2D(0.1, 2))
+    polygon = Polygon2D(pts)
+    polygon_dup = polygon.duplicate()
+    polygon_alt = Polygon2D(pts_2)
+
+    assert polygon is polygon
+    assert polygon is not polygon_dup
+    assert polygon == polygon_dup
+    assert hash(polygon) == hash(polygon_dup)
+    assert polygon != polygon_alt
+    assert hash(polygon) != hash(polygon_alt)
+
+
 def test_polygon2d_to_from_dict():
     """Test the to/from dict of Polygon2D objects."""
     pts = (Point2D(0, 0), Point2D(2, 0), Point2D(2, 2), Point2D(0, 2))

--- a/tests/ray2d_test.py
+++ b/tests/ray2d_test.py
@@ -33,8 +33,8 @@ def test_ray2_to_from_dict():
     assert new_ray.to_dict() == ray_dict
 
 
-def test_ray2d_mutability():
-    """Test the mutability and immutability of Ray2D objects."""
+def test_ray2d_immutability():
+    """Test the immutability of Ray2D objects."""
     pt = Point2D(2, 0)
     vec = Vector2D(0, 2)
     ray = Ray2D(pt, vec)
@@ -52,6 +52,22 @@ def test_ray2d_mutability():
     ray_copy = ray.duplicate()
     assert ray.p == ray_copy.p
     assert ray.v == ray_copy.v
+
+
+def test_equality():
+    """Test the equality of Ray2D objects."""
+    pt = Point2D(2, 0)
+    vec = Vector2D(0, 2)
+    ray = Ray2D(pt, vec)
+    ray_dup = ray.duplicate()
+    ray_alt = Ray2D(Point2D(2, 0.1), vec)
+
+    assert ray is ray
+    assert ray is not ray_dup
+    assert ray == ray_dup
+    assert hash(ray) == hash(ray_dup)
+    assert ray != ray_alt
+    assert hash(ray) != hash(ray_alt)
 
 
 def test_move():

--- a/tests/ray3d_test.py
+++ b/tests/ray3d_test.py
@@ -22,6 +22,22 @@ def test_ray3d_init():
     assert flip_ray.v == Vector3D(0, -2, 0)
 
 
+def test_equality():
+    """Test the equality of Ray3D objects."""
+    pt = Point3D(2, 0, 2)
+    vec = Vector3D(0, 2, 0)
+    ray = Ray3D(pt, vec)
+    ray_dup = ray.duplicate()
+    ray_alt = Ray3D(Point3D(2, 0.1, 2), vec)
+
+    assert ray is ray
+    assert ray is not ray_dup
+    assert ray == ray_dup
+    assert hash(ray) == hash(ray_dup)
+    assert ray != ray_alt
+    assert hash(ray) != hash(ray_alt)
+
+
 def test_ray3_to_from_dict():
     """Test the to/from dict of Ray3D objects."""
     pt = Point3D(2, 0, 2)
@@ -33,7 +49,7 @@ def test_ray3_to_from_dict():
     assert new_ray.to_dict() == ray_dict
 
 
-def test_linerayment2_mutability():
+def test_ray3d_immutability():
     """Test the immutability of Ray3D objects."""
     pt = Point3D(2, 0, 0)
     vec = Vector3D(0, 2, 0)

--- a/tests/sphere3d_test.py
+++ b/tests/sphere3d_test.py
@@ -27,6 +27,20 @@ def test_sphere_init():
     assert isinstance(sp.volume, float)
 
 
+def test_equality():
+    """Test the equality of Polygon2D objects."""
+    sphere = Sphere3D(Point3D(2, 0, 2), 3)
+    sphere_dup = sphere.duplicate()
+    sphere_alt = Sphere3D(Point3D(2, 0.1, 2), 3)
+
+    assert sphere is sphere
+    assert sphere is not sphere_dup
+    assert sphere == sphere_dup
+    assert hash(sphere) == hash(sphere_dup)
+    assert sphere != sphere_alt
+    assert hash(sphere) != hash(sphere_alt)
+
+
 def test_sphere_to_from_dict():
     """Test the Sphere3D to_dict and from_dict methods."""
     sp = Sphere3D(Point3D(4, 0, 2), 3)


### PR DESCRIPTION
I realized that we were overwriting the __eq__ method on a number of objects without overwriting the __hash__ method, which I have come to realize is strongly discouraged in Python. So this commit fixes this by adding hash methods that agree with the __eq__ operator.  This should also allow us to create sets of these geometry objects if we so desire.

The only thing I didn't implement that _might_ be worthwhile to implement in the future is that I am not caching the hash value once it is calculated, which is something that we could do given that all of the geometry objects are immutable. This will allow for quicker hashing if we plan to hash the object multiple times but it also uses up a little more memory per object to store the hash. Right now, we really don't end up hashing the object multiple times in any of our typical workflows such that I think the trade-off isn't worth it. However, we should reconsider this if we find cases in the future where we are hashing the objects multiple times.