### PR TITLE
fix(polyface): Fix method ensuring outward faces

### DIFF
--- a/ladybug_geometry/geometry2d/polygon.py
+++ b/ladybug_geometry/geometry2d/polygon.py
@@ -538,7 +538,7 @@ class Polygon2D(Base2DIn2D):
         While this method covers most fringe cases, it will not test for whether
         a point lies perfectly on the edge of the polygon so it assesses whether
         a point lies inside the polygon up to Python floating point tolerance
-        (1e-16). If distinguishing edge conditions from inside/ outside is
+        (16 digits). If distinguishing edge conditions from inside/ outside is
         important, the `point_relationship` method should be used.
 
         Args:

--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -494,7 +494,7 @@ class Face3D(Base2DIn3D):
         This is useful for getting the vertices of several faces aligned with the
         same global geometry rules for export to engines like EnergyPlus.
         """
-        if self._plane.n.z == 1or self._plane.n.z == -1:  # no vertex is above another
+        if self._plane.n.z == 1 or self._plane.n.z == -1:  # no vertex is above another
             return self.vertices
         # get a 2d polygon in the face plane that has a positive Y axis.
         if self._plane.y.z < 0:
@@ -638,7 +638,7 @@ class Face3D(Base2DIn3D):
             angle_tolerance: The max angle in radians that the plane normals can
                 differ from one another in order for them to be considered coplanar.
         Returns:
-            True if it is a possibe sub-face. False if it is not a valid sub-face.
+            True if it can be a valid sub-face. False if it is not a valid sub-face.
         """
         # test whether the surface is coplanar
         if not self.plane.is_coplanar_tolerance(face.plane, tolerance, angle_tolerance):
@@ -657,6 +657,26 @@ class Face3D(Base2DIn3D):
                 if not hole_poly.is_polygon_outside(sub_poly):
                     return False
             return True
+
+    def is_point_on_face(self, point, tolerance):
+        """Check whether a given point is on this face.
+
+        This includes both a check to be sure that the point is in the plane of this
+        face and a chek to ensure that point lies in the boundary of the face.
+
+        Args:
+            face: Another face for which sub-face equivalency will be tested.
+            tolerance: The minimum difference between the coordinate values of two
+                vertices at which they can be considered equivalent.
+        Returns:
+            True if the point is on the face. False if it is not.
+        """
+        # test whether the point is in the plane of the face
+        if self.plane.distance_to_point(point) > tolerance:
+            return False
+        # if it is, convert the point into this face's plane
+        vert2d = self.plane.xyz_to_xy(point)
+        return self.polygon2d.is_point_inside(vert2d)
 
     def check_planar(self, tolerance, raise_exception=True):
         """Check that all of the face's vertices lie within the face's plane.

--- a/ladybug_geometry/geometry3d/plane.py
+++ b/ladybug_geometry/geometry3d/plane.py
@@ -52,7 +52,7 @@ class Plane(object):
             assert isinstance(x, Vector3D), \
                 "Expected Vector3D for plane X-axis. Got {}.".format(type(x))
             x = x.normalize()
-            assert abs(self._n.x * x.x + self._n.y * x.y + self._n.z * x.z) < 1e-9, \
+            assert abs(self._n.x * x.x + self._n.y * x.y + self._n.z * x.z) < 1e-6, \
                 'Plane X-axis and normal vector are not orthagonal. Got angle of {} ' \
                 'degrees between them.'.format(math.degrees(self._n.angle(x)))
             self._x = x

--- a/ladybug_geometry/geometry3d/polyface.py
+++ b/ladybug_geometry/geometry3d/polyface.py
@@ -740,6 +740,9 @@ class Polyface3D(Base2DIn3D):
                 (v1.x + v2.x / 2), (v1.y + v2.y / 2), (v1.z + v2.z / 2)).normalize()
             move_vec = move_vec * (tolerance + 0.00001)
             point_on_face = face.boundary[0] + move_vec
+            vert2d = face.plane.xyz_to_xy(point_on_face)
+            if not face.polygon2d.is_point_inside(vert2d):  # check that it's on the face
+                point_on_face = face.boundary[0] - move_vec
             test_ray = Ray3D(point_on_face, face.normal)
 
             # if the ray intersects with an even number of other faces, it is correct

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -399,6 +399,24 @@ def test_is_sub_face():
     assert face.is_sub_face(sub_face_5, 0.0001, 0.0001) is False
 
 
+def test_is_point_on_face():
+    """Test the is_point_on_face method."""
+    bound_pts = [Point3D(0, 0), Point3D(4, 0), Point3D(4, 4), Point3D(0, 4)]
+    sub_pt_1 = Point3D(1, 1)
+    sub_pt_2 = Point3D(3, 2)
+    sub_pt_3 = Point3D(6, 2)
+    sub_pt_4 = Point3D(6, 6)
+    sub_pt_5 = Point3D(2, 0, 2)
+    plane_1 = Plane(Vector3D(0, 0, 1))
+    face = Face3D(bound_pts, plane_1)
+
+    assert face.is_point_on_face(sub_pt_1, 0.0001) is True
+    assert face.is_point_on_face(sub_pt_2, 0.0001) is True
+    assert face.is_point_on_face(sub_pt_3, 0.0001) is False
+    assert face.is_point_on_face(sub_pt_4, 0.0001) is False
+    assert face.is_point_on_face(sub_pt_5, 0.0001) is False
+
+
 def test_clockwise():
     """Test the clockwise property."""
     plane_1 = Plane(Vector3D(0, 0, 1))


### PR DESCRIPTION
It seems we needed one final check to be sure that the point we use to test the face's orientation is truly on the face. This fix makes the method capable of catching cases of wide convex angles.