### PR TITLE
feat(bounding): Add a module to compute bounding boxes

### DIFF
--- a/ladybug_geometry/bounding.py
+++ b/ladybug_geometry/bounding.py
@@ -1,0 +1,177 @@
+# coding=utf-8
+"""Utility functions for computing bounding boxes and extents around geometry."""
+from __future__ import division
+
+from ladybug_geometry.geometry2d.pointvector import Point2D
+from ladybug_geometry.geometry3d.pointvector import Point3D
+
+
+def bounding_domain_x(geometries):
+    """Get minimum and maximum X coordinates of multiple geometries.
+
+    Args:
+        geometries: An array of any ladybug_geometry objects for which the extents
+            of the X domain will be computed. Note that all objects must have
+            a min and max property.
+
+    Returns:
+        A tuple with the min and the max X coordinates around the geometry.
+    """
+    min_x, max_x = geometries[0].min.x, geometries[0].max.x
+    for geom in geometries[1:]:
+        if geom.min.x < min_x:
+            min_x = geom.min.x
+        if geom.max.x > max_x:
+            max_x = geom.max.x
+    return min_x, max_x
+
+
+def bounding_domain_y(geometries):
+    """Get minimum and maximum Y coordinates of multiple geometries.
+
+    Args:
+        geometries: An array of any ladybug_geometry objects for which the extents
+            of the Y domain will be computed. Note that all objects must have
+            a min and max property.
+
+    Returns:
+        A tuple with the min and the max Y coordinates around the geometry.
+    """
+    min_y, max_y = geometries[0].min.y, geometries[0].max.y
+    for geom in geometries[1:]:
+        if geom.min.y < min_y:
+            min_y = geom.min.y
+        if geom.max.y > max_y:
+            max_y = geom.max.y
+    return min_y, max_y
+
+
+def bounding_domain_z(geometries):
+    """Get minimum and maximum Z coordinates of multiple geometries.
+
+    Args:
+        geometries: An array of any 3D ladybug_geometry objects for which the extents
+            of the Z domain will be computed. Note that all objects must have
+            a min and max property and they cannot be 2D objects.
+
+    Returns:
+        A tuple with the min and the max Z coordinates around the geometry.
+    """
+    min_z, max_z = geometries[0].min.z, geometries[0].max.z
+    for geom in geometries:
+        if geom.max.z > max_z:
+            max_z = geom.max.z
+        if geom.min.z < min_z:
+            min_z = geom.min.z
+    return min_z, max_z
+
+
+def _orient_geometry(geometries, axis_angle, center):
+    """Orient both 2D and 3D geometry to a given axis angle and center point.
+
+    This is used by the methods that compute bounding rectangles.
+    """
+    new_geometries = []
+    for geom in geometries:
+        try:  # assume that it is a 2D geometry object
+            new_geometries.append(geom.rotate(-axis_angle, center))
+        except TypeError:  # it's a 3D geometry object
+            new_geometries.append(geom.rotate_xy(-axis_angle, center))
+    return new_geometries
+
+
+def bounding_rectangle(geometries, axis_angle=0):
+    """Get the min and max of an oriented bounding rectangle around 2D or 3D geometry.
+
+    Args:
+        geometries: An array of 2D or 3D geometry objects. Note that all objects
+            must have a min and max property.
+        axis_angle: The counter-clockwise rotation angle in radians in the XY plane
+            to represent the orientation of the bounding rectangle extents. (Default: 0).
+
+    Returns:
+        A tuple with two Point2D objects representing the min point and max point
+        of the bounding rectangle respectively.
+    """
+    if axis_angle != 0:  # rotate geometry to the bounding box
+        cpt = geometries[0].vertices[0]
+        geometries = _orient_geometry(geometries, axis_angle, cpt)
+    xx = bounding_domain_x(geometries)
+    yy = bounding_domain_y(geometries)
+    min_pt = Point2D(xx[0], yy[0])
+    max_pt = Point2D(xx[1], yy[1])
+    if axis_angle != 0:  # rotate the points back
+        cpt = Point2D(cpt.x, cpt.y)  # cast Point3D to Point2D
+        min_pt = min_pt.rotate(axis_angle, cpt)
+        max_pt = max_pt.rotate(axis_angle, cpt)
+    return min_pt, max_pt
+
+
+def bounding_rectangle_extents(geometries, axis_angle=0):
+    """Get the width and length of an oriented bounding rectangle around 2D or 3D geometry.
+
+    Args:
+        geometries: An array of 2D or 3D geometry objects. Note that all objects
+            must have a min and max property.
+        axis_angle: The counter-clockwise rotation angle in radians in the XY plane
+            to represent the orientation of the bounding rectangle extents. (Default: 0).
+
+    Returns:
+        A tuple with 2 values corresponding to the width and length of the bounding
+        rectangle.
+    """
+    if axis_angle != 0:
+        cpt = geometries[0].vertices[0]
+        geometries = _orient_geometry(geometries, axis_angle, cpt)
+    xx = bounding_domain_x(geometries)
+    yy = bounding_domain_y(geometries)
+    return xx[1] - xx[0], yy[1] - yy[0]
+
+
+def bounding_box(geometries, axis_angle=0):
+    """Get the min and max of an oriented bounding box around 3D geometry.
+
+    Args:
+        geometries: An array of 3D geometry objects. Note that all objects must
+            have a min and max property.
+        axis_angle: The counter-clockwise rotation angle in radians in the XY plane
+            to represent the orientation of the bounding box extents. (Default: 0).
+
+    Returns:
+        A tuple with two Point3D objects representing the min point and max point
+        of the bounding box respectively.
+    """
+    if axis_angle != 0:  # rotate geometry to the bounding box
+        cpt = geometries[0].vertices[0]
+        geometries = [geom.rotate_xy(-axis_angle, cpt) for geom in geometries]
+    xx = bounding_domain_x(geometries)
+    yy = bounding_domain_y(geometries)
+    zz = bounding_domain_z(geometries)
+    min_pt = Point3D(xx[0], yy[0], zz[0])
+    max_pt = Point3D(xx[1], yy[1], zz[1])
+    if axis_angle != 0:  # rotate the points back
+        min_pt = min_pt.rotate_xy(axis_angle, cpt)
+        max_pt = max_pt.rotate_xy(axis_angle, cpt)
+    return min_pt, max_pt
+
+
+def bounding_box_extents(geometries, axis_angle=0):
+    """Get the width, length and height of an oriented bounding box around 3D geometry.
+
+    Args:
+        geometries: An array of 3D geometry objects. Note that all objects must
+            have a min and max property.
+        axis_angle: The counter-clockwise rotation angle in radians in the XY plane
+            to represent the orientation of the bounding box extents. (Default: 0).
+
+    Returns:
+        A tuple with 3 values corresponding to the width, length and height of
+        the bounding box.
+    """
+    if axis_angle != 0:
+        cpt = geometries[0].vertices[0]
+        geometries = [geom.rotate_xy(-axis_angle, cpt) for geom in geometries]
+    xx = bounding_domain_x(geometries)
+    yy = bounding_domain_y(geometries)
+    zz = bounding_domain_z(geometries)
+    return xx[1] - xx[0], yy[1] - yy[0], zz[1] - zz[0]

--- a/tests/bounding_test.py
+++ b/tests/bounding_test.py
@@ -1,0 +1,109 @@
+from ladybug_geometry.geometry2d.pointvector import Point2D, Vector2D
+from ladybug_geometry.geometry2d.polygon import Polygon2D
+from ladybug_geometry.geometry3d.pointvector import Point3D
+from ladybug_geometry.geometry3d.plane import Plane
+from ladybug_geometry.geometry3d.polyface import Polyface3D
+from ladybug_geometry.bounding import bounding_box, bounding_box_extents, \
+    bounding_rectangle, bounding_rectangle_extents
+
+import pytest
+
+
+def test_bounding_box():
+    """Test the bounding_box methods with arrays of 3D objects."""
+    plane1 = Plane(o=Point3D(-5, 0, 0))
+    plane2 = Plane(o=Point3D(0, -4, 4))
+    plane3 = Plane(o=Point3D(2, 2, -4))
+    polyface1 = Polyface3D.from_box(2, 4, 2, plane1)
+    polyface2 = Polyface3D.from_box(2, 4, 2, plane2)
+    polyface3 = Polyface3D.from_box(2, 4, 2, plane3)
+
+    min_pt, max_pt = bounding_box([polyface1, polyface2, polyface3])
+    assert min_pt == Point3D(-5, -4, -4)
+    assert max_pt == Point3D(4, 6, 6)
+
+    x_dom, y_dom, z_dom = bounding_box_extents([polyface1, polyface2, polyface3])
+    assert x_dom == 9
+    assert y_dom == 10
+    assert z_dom == 10
+
+
+def test_bounding_box_angle():
+    """Test the bounding_box methods with an axis_angle."""
+    plane1 = Plane(o=Point3D(-5, 0, 0))
+    plane2 = Plane(o=Point3D(0, -4, 4))
+    plane3 = Plane(o=Point3D(2, 2, -4))
+    polyface1 = Polyface3D.from_box(2, 4, 2, plane1)
+    polyface2 = Polyface3D.from_box(2, 4, 2, plane2)
+    polyface3 = Polyface3D.from_box(2, 4, 2, plane3)
+
+    min_pt, max_pt = bounding_box([polyface1, polyface2, polyface3], 45)
+    assert min_pt.x == pytest.approx(1.45, rel=1e-2)
+    assert min_pt.y == pytest.approx(-4.89, rel=1e-2)
+    assert min_pt.z == pytest.approx(-4, rel=1e-2)
+    assert max_pt.x == pytest.approx(-1.62, rel=1e-2)
+    assert max_pt.y == pytest.approx(9.47, rel=1e-2)
+    assert max_pt.z == pytest.approx(6, rel=1e-2)
+
+    x_dom, y_dom, z_dom = bounding_box_extents([polyface1, polyface2, polyface3], 45)
+    assert x_dom == pytest.approx(10.6103, rel=1e-2)
+    assert y_dom == pytest.approx(10.1589, rel=1e-2)
+    assert z_dom == pytest.approx(10, rel=1e-2)
+
+
+def test_bounding_rectangle():
+    """Test the bounding_rectangle methods with arrays of 3D objects."""
+    plane1 = Plane(o=Point3D(-5, 0, 0))
+    plane2 = Plane(o=Point3D(0, -4, 4))
+    plane3 = Plane(o=Point3D(2, 2, -4))
+    polyface1 = Polyface3D.from_box(2, 4, 2, plane1)
+    polyface2 = Polyface3D.from_box(2, 4, 2, plane2)
+    polyface3 = Polyface3D.from_box(2, 4, 2, plane3)
+
+    min_pt, max_pt = bounding_rectangle([polyface1, polyface2, polyface3])
+    assert min_pt == Point2D(-5, -4)
+    assert max_pt == Point2D(4, 6)
+
+    x_dom, y_dom = bounding_rectangle_extents([polyface1, polyface2, polyface3])
+    assert x_dom == 9
+    assert y_dom == 10
+
+
+def test_bounding_rectangle_angle():
+    """Test the bounding_rectangle methods with an axis_angle."""
+    plane1 = Plane(o=Point3D(-5, 0, 0))
+    plane2 = Plane(o=Point3D(0, -4, 4))
+    plane3 = Plane(o=Point3D(2, 2, -4))
+    polyface1 = Polyface3D.from_box(2, 4, 2, plane1)
+    polyface2 = Polyface3D.from_box(2, 4, 2, plane2)
+    polyface3 = Polyface3D.from_box(2, 4, 2, plane3)
+
+    min_pt, max_pt = bounding_rectangle([polyface1, polyface2, polyface3], 45)
+    assert min_pt.x == pytest.approx(1.45, rel=1e-2)
+    assert min_pt.y == pytest.approx(-4.89, rel=1e-2)
+    assert max_pt.x == pytest.approx(-1.62, rel=1e-2)
+    assert max_pt.y == pytest.approx(9.47, rel=1e-2)
+
+    x_dom, y_dom = bounding_rectangle_extents([polyface1, polyface2, polyface3], 45)
+    assert x_dom == pytest.approx(10.6103, rel=1e-2)
+    assert y_dom == pytest.approx(10.1589, rel=1e-2)
+
+
+def test_bounding_rectangle_angle_2d():
+    """Test the bounding_rectangle methods with an axis_angle and 2D geometry."""
+    pt1 = Point2D(-5, 0)
+    pt2 = Point2D(0, -4)
+    pt3 = Point2D(2, 2)
+    polyface1 = Polygon2D.from_rectangle(pt1, Vector2D(0, 1), 2, 4)
+    polyface2 = Polygon2D.from_rectangle(pt2, Vector2D(0, 1), 2, 4)
+    polyface3 = Polygon2D.from_rectangle(pt3, Vector2D(0, 1),2, 4)
+
+    min_pt, max_pt = bounding_rectangle([polyface1, polyface2, polyface3], 45)
+    assert min_pt.x == pytest.approx(1.45, rel=1e-2)
+    assert min_pt.y == pytest.approx(-4.89, rel=1e-2)
+    assert max_pt.x == pytest.approx(-1.62, rel=1e-2)
+    assert max_pt.y == pytest.approx(9.47, rel=1e-2)
+
+    x_dom, y_dom = bounding_rectangle_extents([polyface1, polyface2, polyface3], 45)
+    assert x_dom == pytest.approx(10.6103, rel=1e-2)
+    assert y_dom == pytest.approx(10.1589, rel=1e-2)

--- a/tests/polyface3d_test.py
+++ b/tests/polyface3d_test.py
@@ -251,9 +251,9 @@ def test_polyface3d_init_from_faces_tolerance():
     polyface_1 = Polyface3D.from_faces(
         [face_1, face_2, face_3, face_4, face_5, face_6], 0.001)
     polyface_2 = Polyface3D.from_faces(
-        [face_1, face_2, face_3, face_4, face_5, face_7],  0.001)
+        [face_1, face_2, face_3, face_4, face_5, face_7], 0.001)
     polyface_3 = Polyface3D.from_faces(
-        [face_1, face_2, face_3, face_4, face_5, face_7],  0.000001)
+        [face_1, face_2, face_3, face_4, face_5, face_7], 0.000001)
 
     assert polyface_1.is_solid
     assert polyface_2.is_solid
@@ -329,7 +329,7 @@ def test_polyface3d_init_from_offset_face_hexagon():
 
 
 def test_polyface3d_init_from_offset_face_hole():
-    """Test the initialization of Polyface3D from_offset_face for a face witha hole."""
+    """Test the initialization of Polyface3D from_offset_face for a face with a hole."""
     bound_pts = [Point3D(0, 0), Point3D(3, 0), Point3D(3, 3), Point3D(0, 3)]
     hole_pts = [Point3D(1, 1), Point3D(2, 1), Point3D(2, 2), Point3D(1, 2)]
     face = Face3D(bound_pts, None, [hole_pts])
@@ -595,7 +595,7 @@ def test_rotate():
     assert polyface.volume == test_1.volume
     assert len(polyface.vertices) == len(test_1.vertices)
 
-    test_2 = polyface.rotate(axis, math.pi/2, origin)
+    test_2 = polyface.rotate(axis, math.pi / 2, origin)
     assert test_2[0].x == pytest.approx(0, rel=1e-3)
     assert test_2[0].y == pytest.approx(-2, rel=1e-3)
     assert test_2[0].z == pytest.approx(0, rel=1e-3)
@@ -620,7 +620,7 @@ def test_rotate_xy():
     assert test_1[2].y == pytest.approx(0, rel=1e-3)
     assert test_1[2].z == pytest.approx(2, rel=1e-3)
 
-    test_2 = polyface.rotate_xy(math.pi/2, origin_1)
+    test_2 = polyface.rotate_xy(math.pi / 2, origin_1)
     assert test_2[0].x == pytest.approx(1, rel=1e-3)
     assert test_2[0].y == pytest.approx(1, rel=1e-3)
     assert test_1[0].z == pytest.approx(2, rel=1e-3)


### PR DESCRIPTION
This commit adds a module for computing bounding boxes and rectangles around arrays of ladybug geometry, which I have come to realize is something that's needed throughout several of the core libraries.

Resolves https://github.com/ladybug-tools/ladybug-geometry/issues/173