### PR TITLE
fix(mesh): Handle the case of lists describing mesh faces

### DIFF
--- a/ladybug_geometry/geometry2d/mesh.py
+++ b/ladybug_geometry/geometry2d/mesh.py
@@ -80,8 +80,8 @@ class Mesh2D(MeshBase):
                 raise ImportError('Colors are specified in input Mesh2D dictionary '
                                   'but failed to import ladybug.color')
             colors = tuple(Color.from_dict(col) for col in data['colors'])
-        return cls(tuple(Point2D.from_array(pt) for pt in data['vertices']),
-                   data['faces'], colors)
+        fcs = tuple(tuple(f) for f in data['faces'])  # cast to immutable type
+        return cls(tuple(Point2D.from_array(pt) for pt in data['vertices']), fcs, colors)
 
     @classmethod
     def from_face_vertices(cls, faces, purge=True):

--- a/ladybug_geometry/geometry3d/mesh.py
+++ b/ladybug_geometry/geometry3d/mesh.py
@@ -82,8 +82,8 @@ class Mesh3D(MeshBase):
                 raise ImportError('Colors are specified in input Mesh2D dictionary '
                                   'but failed to import ladybug.color')
             colors = tuple(Color.from_dict(col) for col in data['colors'])
-        return cls(tuple(Point3D.from_array(pt) for pt in data['vertices']),
-                   data['faces'], colors)
+        fcs = tuple(tuple(f) for f in data['faces'])  # cast to immutable type
+        return cls(tuple(Point3D.from_array(pt) for pt in data['vertices']), fcs, colors)
 
     @classmethod
     def from_face_vertices(cls, faces, purge=True):

--- a/tests/mesh3d_test.py
+++ b/tests/mesh3d_test.py
@@ -8,6 +8,8 @@ from ladybug_geometry.geometry2d.mesh import Mesh2D
 from ladybug_geometry.geometry2d.pointvector import Point2D
 
 import math
+import json
+import os
 
 
 def test_mesh3d_init():
@@ -63,6 +65,22 @@ def test_mesh3d_to_from_dict():
     new_mesh = Mesh3D.from_dict(mesh_dict)
     assert isinstance(new_mesh, Mesh3D)
     assert new_mesh.to_dict() == mesh_dict
+
+
+def test_mesh3d_to_from_json():
+    """Test the to/from dict with JSON serialization of Mesh3D objects."""
+    pts = (Point3D(0, 0), Point3D(0, 2), Point3D(2, 2), Point3D(2, 0))
+    mesh = Mesh3D(pts, [(0, 1, 2, 3)])
+    mesh_dict = mesh.to_dict()
+    geo_file = './tests/json/json_mesh.json'
+    with open(geo_file, 'w') as fp:
+        json.dump(mesh_dict, fp)
+    with open(geo_file, 'r') as fp:
+        new_mesh_dict = json.load(fp)
+    new_mesh = Mesh3D.from_dict(new_mesh_dict)
+    assert isinstance(new_mesh, Mesh3D)
+    assert new_mesh.to_dict() == mesh_dict
+    os.remove(geo_file)
 
 
 def test_face_normals():


### PR DESCRIPTION
Given that all tuples get cast to a list with JSON serialization, the Mesh.from_dict methods need to handle the casting of these lists back to tuples for the mesh face indices.