### PR TITLE
fix(polyline): Add properties to easily access polyline endoints

### DIFF
--- a/ladybug_geometry/geometry2d/polyline.py
+++ b/ladybug_geometry/geometry2d/polyline.py
@@ -27,6 +27,8 @@ class Polyline2D(Base2DIn2D):
         * min
         * max
         * center
+        * p1
+        * p2
         * length
         * is_self_intersecting
         * interpolated
@@ -91,6 +93,16 @@ class Polyline2D(Base2DIn2D):
         if self._length is None:
             self._length = sum([seg.length for seg in self.segments])
         return self._length
+
+    @property
+    def p1(self):
+        """Starting point of the Polyline2D."""
+        return self._vertices[0]
+
+    @property
+    def p2(self):
+        """End point of the Polyline2D."""
+        return self._vertices[-1]
 
     @property
     def is_self_intersecting(self):

--- a/ladybug_geometry/geometry3d/polyline.py
+++ b/ladybug_geometry/geometry3d/polyline.py
@@ -30,6 +30,8 @@ class Polyline3D(Base2DIn3D):
         * min
         * max
         * center
+        * p1
+        * p2
         * length
         * interpolated
     """
@@ -87,6 +89,16 @@ class Polyline3D(Base2DIn3D):
                 tuple(LineSegment3D.from_end_points(vert, self._vertices[i + 1])
                       for i, vert in enumerate(self._vertices[:-1]))
         return self._segments
+
+    @property
+    def p1(self):
+        """Starting point of the Polyline3D."""
+        return self._vertices[0]
+
+    @property
+    def p2(self):
+        """End point of the Polyline3D."""
+        return self._vertices[-1]
 
     @property
     def length(self):

--- a/tests/polyline2d_test.py
+++ b/tests/polyline2d_test.py
@@ -11,7 +11,7 @@ import math
 
 
 def test_polyline2d_init():
-    """Test the initalization of Polyline2D objects and basic properties."""
+    """Test the initialization of Polyline2D objects and basic properties."""
     pts = (Point2D(0, 0), Point2D(2, 0), Point2D(2, 2), Point2D(0, 2))
     pline = Polyline2D(pts)
 
@@ -28,6 +28,9 @@ def test_polyline2d_init():
     for seg in pline.segments:
         assert isinstance(seg, LineSegment2D)
         assert seg.length == 2
+
+    assert pline.p1 == pts[0]
+    assert pline.p2 == pts[-1]
 
     assert pline.length == 6
     assert pline.is_self_intersecting is False

--- a/tests/polyline3d_test.py
+++ b/tests/polyline3d_test.py
@@ -12,7 +12,7 @@ import math
 
 
 def test_polyline3d_init():
-    """Test the initalization of Polyline3D objects and basic properties."""
+    """Test the initialization of Polyline3D objects and basic properties."""
     pts = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 2), Point3D(0, 2))
     pline = Polyline3D(pts)
 
@@ -29,6 +29,9 @@ def test_polyline3d_init():
     for seg in pline.segments:
         assert isinstance(seg, LineSegment3D)
         assert seg.length == 2
+
+    assert pline.p1 == pts[0]
+    assert pline.p2 == pts[-1]
 
     assert pline.length == 6
     assert pline.vertices[0] == pline[0]


### PR DESCRIPTION
I have come to realize that this will make a lot of my code that's higher in the dependency tree a lot cleaner, even though it's technically not necessary.  It's just that there are more cases where I have a mix of polylines and line segments than I originally realized.