### PR TITLE
fix(mesh): Force the regeneration of normals after joining

### DIFF
--- a/ladybug_geometry/geometry3d/mesh.py
+++ b/ladybug_geometry/geometry3d/mesh.py
@@ -382,14 +382,6 @@ class Mesh3D(MeshBase):
             new_mesh = Mesh3D(verts, faces, colors)
         else:
             new_mesh = Mesh3D(verts, faces)
-
-        # attempt to transfer the centroids and normals
-        if all(msh._face_centroids is not None for msh in meshes):
-            new_mesh._face_centroids = tuple(pt for msh in meshes for pt in msh)
-        if all(msh._face_normals is not None for msh in meshes):
-            new_mesh._face_normals = tuple(v for msh in meshes for v in msh.face_normals)
-        if all(msh._face_areas is not None for msh in meshes):
-            new_mesh._face_areas = tuple(a for msh in meshes for a in msh.face_areas)
         return new_mesh
 
     def _calculate_min_max(self):

--- a/tests/mesh3d_test.py
+++ b/tests/mesh3d_test.py
@@ -469,5 +469,3 @@ def test_join_meshes():
     assert isinstance(joined_mesh, Mesh3D)
     assert len(joined_mesh.faces) == 2
     assert len(joined_mesh.vertices) == 8
-    assert joined_mesh._face_centroids is not None
-    assert joined_mesh._face_normals is not None


### PR DESCRIPTION
I know that I originally put this code here to save time but it is definitely buggy and, in the grand scheme of things, it's more important that the joining of meshes be reliable than having to wait a few extra seconds at most to regenerate face normals.