### PR TITLE
chore(deps-dev): Simplify updates of dev dependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,6 +3,27 @@ update_configs:
   - package_manager: "python"
     directory: "/"
     update_schedule: "live"
+    ignored_updates:
+      - match:
+          dependency_name: "Sphinx"
+      - match:
+          dependency_name: "sphinx-click"
+      - match:
+          dependency_name: "sphinxcontrib-websupport"
+      - match:
+          dependency_name: "coveralls"
+      -match:
+          dependency_name: "coverage"
+      -match:
+          dependency_name: "pytest"
+      -match:
+          dependency_name: "pytest-cov"
+      -match:
+          dependency_name: "twine"
+      -match:
+          dependency_name: "setuptools"
+      -match:
+          dependency_name: "importlib-metadata"
     automerged_updates:
       - match:
           dependency_type: "all"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ pytest==4.6.9;python_version<'3.0'
 pytest==6.2.4;python_version>='3.6'
 pytest-cov==2.12.0
 Sphinx==1.8.5;python_version<'3.0'
-Sphinx==3.5.4;python_version>='3.6'
+Sphinx==3.3.1;python_version>='3.6'
 sphinx-bootstrap-theme==0.7.1
 sphinxcontrib-fulltoc==1.2.0
 sphinxcontrib-websupport==1.1.2;python_version<'3.0'
@@ -16,5 +16,5 @@ twine==3.4.1;python_version>='3.6'
 wheel==0.36.2
 setuptools==44.1.0;python_version<'3.0'
 setuptools==57.0.0;python_version>='3.6'
-importlib-metadata==4.0.1;python_version>='3.6'
 importlib-metadata==2.0.0;python_version<'3.0'
+importlib-metadata==4.0.1;python_version>='3.6'


### PR DESCRIPTION
We really don't need these to be at the bleeding edge, especially when the latest versions of them conflict with one another.