### PR TITLE
Ladybug Geometry 'dictutil' converter function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+.venv/
 test.py
 .pytest_cache
 *__pycache__

--- a/ladybug_geometry/dictutil.py
+++ b/ladybug_geometry/dictutil.py
@@ -6,24 +6,22 @@ Ladybug_geometry library in order to be able to re-serialize almost any
 dictionary produced from the library.
 """
 
-from ladybug_geometry.geometry2d import (Vector2D, Point2D, Ray2D, 
-                            LineSegment2D, Arc2D, Polyline2D, Polygon2D, Mesh2D)
-from ladybug_geometry.geometry3d import (Vector3D, Point3D, Ray3D,
-                            LineSegment3D, Arc3D, Polyline3D, Polyface3D, Mesh3D,
-                            Plane, Face3D, Sphere, Cone, Cylinder)
+from ladybug_geometry.geometry2d import Vector2D, Point2D, Ray2D, \
+                            LineSegment2D, Arc2D, Polyline2D, Polygon2D, Mesh2D
+from ladybug_geometry.geometry3d import Vector3D, Point3D, Ray3D, \
+                            LineSegment3D, Arc3D, Polyline3D, Polyface3D, Mesh3D,\
+                            Plane, Face3D, Sphere, Cone, Cylinder
 
 def geometry_dict_to_object(ladybug_geom_dict, raise_exception=True):
-    # type (dict, bool) -> object | None
     """
     Args:
-        ladybug_geom_dict (dict): A dictionary of any Ladybug Geometry object. Note
-            that this should be a non-abridged dictionary to be valid.
+        ladybug_geom_dict (dict): A dictionary of any Ladybug Geometry object.
         raise_exception (bool): Boolean to note whether an exception should be raised
-            if the object is not identified as a part of honeybee.
+            if the object is not identified as a part of ladybug_geometry.
             Default: True.
 
     Returns:
-        Optional[object]: A Python object derived from the input ladybug_geom_dict. 
+        A Python object derived from the input ladybug_geom_dict. 
     """
 
     lbt_types = {
@@ -50,13 +48,13 @@ def geometry_dict_to_object(ladybug_geom_dict, raise_exception=True):
         'Cylinder':Cylinder,
     }
 
-    #- Get the Object Type
+    # Get the ladybug_geometry object 'Type'
     try:
         obj_type = ladybug_geom_dict['type']
     except KeyError:
         raise ValueError('Ladybug dictionary lacks required "type" key.')
 
-    #- Build a new Ladybug Object based on the "Type"
+    # Build a new Ladybug Python Object based on the "Type"
     try:
         lbt_class = lbt_types[obj_type]
         return lbt_class.from_dict( ladybug_geom_dict )

--- a/ladybug_geometry/dictutil.py
+++ b/ladybug_geometry/dictutil.py
@@ -12,7 +12,8 @@ from ladybug_geometry.geometry3d import (Vector3D, Point3D, Ray3D,
                             LineSegment3D, Arc3D, Polyline3D, Polyface3D, Mesh3D,
                             Plane, Face3D, Sphere, Cone, Cylinder)
 
-def lb_geom_dict_to_object(ladybug_geom_dict, raise_exception=True): #-> Optional[object]
+def geometry_dict_to_object(ladybug_geom_dict, raise_exception=True):
+    # type (dict, bool) -> object | None
     """
     Args:
         ladybug_geom_dict (dict): A dictionary of any Ladybug Geometry object. Note

--- a/tests/dictutil_test.py
+++ b/tests/dictutil_test.py
@@ -2,19 +2,30 @@
 
 Note: Written in PyTest format.
 """
-
+import pytest
 from ladybug_geometry.geometry2d import (Vector2D, Point2D, Ray2D, 
                             LineSegment2D, Arc2D, Polyline2D, Polygon2D, Mesh2D)
 from ladybug_geometry.geometry3d import (Vector3D, Point3D, Ray3D,
                             LineSegment3D, Arc3D, Polyline3D, Polyface3D, Mesh3D,
                             Plane, Face3D, Sphere, Cone, Cylinder)
-from lb_dictutil import lb_geom_dict_to_object
+from ladybug_geometry.dictutil import geometry_dict_to_object
+
+#--- Test not Ladubug Geometry dict
+def test_not_valid_dict():
+    d = { 'key_1':'val_1' } # dict Does NOT inlcude 'type' key
+    with pytest.raises(ValueError):
+        obj = geometry_dict_to_object( d )
+
+def test_not_valid_dict():
+    d = { 'type':'not_a_valid_type' } # Includes 'type', but is not a valid Ladybug Type
+    with pytest.raises(ValueError):
+        obj = geometry_dict_to_object( d )
 
 #--- Test 2D Geometry
 def test_Point2D():
     obj1 = Point2D()
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -22,14 +33,14 @@ def test_Arc2D():
     pt1 = Point2D()
     obj1 = Arc2D(pt1, 2)
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
 def test_Vector2D():
     obj1 = Vector2D(0,1)
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -38,7 +49,7 @@ def test_Ray2D():
     v1 = Vector2D(0,1)
     obj1 = Ray2D(pt1,v1)
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -47,7 +58,7 @@ def test_LineSegment2D():
     v1 = Vector2D(0,1)
     obj1 = LineSegment2D(pt1,v1)
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -57,7 +68,7 @@ def test_Polyline2D():
     pt3 = Point2D(2,3)
     obj1 = Polyline2D([pt1, pt2, pt3], False)
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -68,7 +79,7 @@ def test_Polygon2D():
     pt4 = Point2D(0,1)
     obj1 = Polygon2D([pt1, pt2, pt3, pt4])
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -79,7 +90,7 @@ def test_Mesh2D():
     pt4 = Point2D(0,1)
     obj1 = Mesh2D(vertices=(pt1, pt2, pt3, pt4), faces=[(0,1,2)] )
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -87,7 +98,7 @@ def test_Mesh2D():
 def test_Point3D():
     obj1 = Point3D()
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -95,14 +106,14 @@ def test_Arc3D():
     pl = Plane()
     obj1 = Arc3D(pl, 2)
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
 def test_Vector3D():
     obj1 = Vector3D(0,1)
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -111,7 +122,7 @@ def test_Ray3D():
     v1 = Vector3D(0,1)
     obj1 = Ray3D(pt1,v1)
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -120,7 +131,7 @@ def test_LineSegment3D():
     v1 = Vector3D(0,1)
     obj1 = LineSegment3D(pt1,v1)
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -130,7 +141,7 @@ def test_Polyline3D():
     pt3 = Point3D(2,3)
     obj1 = Polyline3D([pt1, pt2, pt3], False)
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -141,7 +152,7 @@ def test_Polyface3D():
     pt4 = Point3D(0,1)
     obj1 = Polyface3D(vertices=[pt1, pt2, pt3, pt4], face_indices=[ [[1]] ] )
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -153,14 +164,14 @@ def test_Mesh3D():
     obj1 = Mesh3D(vertices=(pt1, pt2, pt3, pt4), faces=[(0,1,2)] )
     
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
 def test_Plane():
     obj1 = Plane()
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -170,7 +181,7 @@ def test_Face3D():
     pt3 = Point3D(2,3)
     obj1 = Face3D([pt1, pt2, pt3])
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -178,7 +189,7 @@ def test_Sphere():
     pt1 = Point3D()
     obj1 = Sphere(pt1, 1)
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -187,7 +198,7 @@ def test_Cone():
     axis = Vector3D(0,0,1)
     obj1 = Cone(v1, axis, 45)
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
 
@@ -196,30 +207,6 @@ def test_Cylinder():
     axis = Vector3D(0,0,1)
     obj1 = Cylinder(v1, axis, 10)
     d = obj1.to_dict()
-    obj2 = lb_geom_dict_to_object(d)
+    obj2 = geometry_dict_to_object(d)
 
     assert obj2 == obj1
-
-# if __name__ == '__main__':
-#     test_Point2D()
-#     test_Arc2D()
-#     test_Vector2D()
-#     test_Ray2D()
-#     test_LineSegment2D()
-#     test_Polyline2D()
-#     test_Polygon2D()
-#     test_Mesh2D()
-
-#     test_Point3D()
-#     test_Arc3D()
-#     test_Vector3D()
-#     test_Ray3D()
-#     test_LineSegment3D()
-#     test_Polyline3D()
-#     test_Polyface3D()
-#     test_Mesh3D()
-#     test_Plane()
-#     test_Face3D()
-#     test_Sphere()
-#     test_Cone()
-#     test_Cylinder()


### PR DESCRIPTION
Adds a new converter function to ladybug_geometry. Similar to the existing 'dictutil' for Honeybee. Takes in a dict and converts to back Ladybug Geometry Object (reverses the .to_dict method). Includes unit tests.