### PR TITLE
fix(face): Avoid removing the last vertex twice

### DIFF
--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -1747,6 +1747,11 @@ class Face3D(Base2DIn3D):
                 skip = 0
             else:
                 skip += 1
+        if skip != 0 and pts_3d[-2].is_equivalent(pts_3d[-1], tolerance):
+            _a = pts_2d[-3].determinant(pts_2d[-1]) + \
+                pts_2d[-1].determinant(pts_2d[0]) + pts_2d[0].determinant(pts_2d[-3])
+            if abs(_a) >= tolerance:
+                new_vertices.append(pts_3d[-1])
         return new_vertices
 
     def _is_sub_face(self, face):

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -594,12 +594,24 @@ def test_remove_colinear_vertices():
     pts_1 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 2), Point3D(0, 2))
     pts_2 = (Point3D(0, 0), Point3D(1, 0), Point3D(2, 0), Point3D(2, 2),
              Point3D(0, 2))
+    pts_3 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 2),
+             Point3D(0, 2), Point3D(0, 2))
+    pts_4 = (Point3D (24.21, 23.22, 8.00), Point3D (24.21, 23.22, 11.60),
+             Point3D (24.61, 23.22, 11.60), Point3D (27.85, 23.22, 11.60),
+             Point3D (30.28, 23.22, 11.60), Point3D (30.28, 23.22, 0.00),
+             Point3D (27.85, 23.22, 0.00), Point3D (27.85, 23.22, 4.00),
+             Point3D (27.85, 23.22, 8.00), Point3D (27.85, 23.22, 8.00),
+             Point3D (24.61, 23.22, 8.00), Point3D (24.61, 23.22, 8.00))
     plane_1 = Plane(Vector3D(0, 0, 1))
     face_1 = Face3D(pts_1, plane_1)
     face_2 = Face3D(pts_2, plane_1)
+    face_3 = Face3D(pts_3, plane_1)
+    face_4 = Face3D(pts_4)
 
     assert len(face_1.remove_colinear_vertices(0.0001).vertices) == 4
     assert len(face_2.remove_colinear_vertices(0.0001).vertices) == 4
+    assert len(face_3.remove_colinear_vertices(0.0001).vertices) == 4
+    assert len(face_4.remove_colinear_vertices(0.0001).vertices) == 6
 
 
 def test_remove_colinear_vertices_custom():


### PR DESCRIPTION
It seems that the remove_colinear_vertices method would remove the last vertex twice if those last two vertices were equivalent to one another. This is not necessarily what you want unless both of those last two vertices are colinear with the vertices surrounding it. This commit fixes this case.