### PR TITLE
fix(face): Add property and methods to get Point2Ds in a Face3D plane

### DIFF
--- a/ladybug_geometry/geometry2d/arc.py
+++ b/ladybug_geometry/geometry2d/arc.py
@@ -60,11 +60,11 @@ class Arc2D(object):
         .. code-block:: python
 
             {
-            "type": "Arc2D"
-            "c": (10, 0),
-            "r": 5,
-            "a1": 0,
-            "a2": 3.14159
+                "type": "Arc2D"
+                "c": (10, 0),
+                "r": 5,
+                "a1": 0,
+                "a2": 3.14159
             }
         """
         return cls(Point2D.from_array(data['c']),

--- a/ladybug_geometry/geometry2d/mesh.py
+++ b/ladybug_geometry/geometry2d/mesh.py
@@ -67,10 +67,10 @@ class Mesh2D(MeshBase):
         .. code-block:: python
 
             {
-            "type": "Mesh2D",
-            "vertices": [(0, 0), (10, 0), (0, 10)],
-            "faces": [(0, 1, 2)],
-            "colors": [{"r": 255, "g": 0, "b": 0}]
+                "type": "Mesh2D",
+                "vertices": [(0, 0), (10, 0), (0, 10)],
+                "faces": [(0, 1, 2)],
+                "colors": [{"r": 255, "g": 0, "b": 0}]
             }
         """
         colors = None

--- a/ladybug_geometry/geometry2d/pointvector.py
+++ b/ladybug_geometry/geometry2d/pointvector.py
@@ -37,8 +37,8 @@ class Vector2D(object):
         .. code-block:: python
 
             {
-            "x": 10,
-            "y": 0
+                "x": 10,
+                "y": 0
             }
         """
         return cls(data['x'], data['y'])

--- a/ladybug_geometry/geometry2d/polygon.py
+++ b/ladybug_geometry/geometry2d/polygon.py
@@ -55,8 +55,8 @@ class Polygon2D(Base2DIn2D):
         .. code-block:: python
 
             {
-            "type": "Polygon2D",
-            "vertices": [(0, 0), (10, 0), (0, 10)]
+                "type": "Polygon2D",
+                "vertices": [(0, 0), (10, 0), (0, 10)]
             }
         """
         return cls(tuple(Point2D.from_array(pt) for pt in data['vertices']))

--- a/ladybug_geometry/geometry2d/polyline.py
+++ b/ladybug_geometry/geometry2d/polyline.py
@@ -53,8 +53,8 @@ class Polyline2D(Base2DIn2D):
         .. code-block:: python
 
             {
-            "type": "Polyline2D",
-            "vertices": [(0, 0), (10, 0), (0, 10)]
+                "type": "Polyline2D",
+                "vertices": [(0, 0), (10, 0), (0, 10)]
             }
         """
         interp = data['interpolated'] if 'interpolated' in data else False

--- a/ladybug_geometry/geometry3d/arc.py
+++ b/ladybug_geometry/geometry3d/arc.py
@@ -54,11 +54,11 @@ class Arc3D(object):
         .. code-block:: python
 
             {
-            "type": "Arc3D"
-            "plane": {"n": (0, 0, 1), "o": (0, 10, 0), "x": (1, 0, 0)},
-            "radius": 5,
-            "a1": 0,
-            "a2": 3.14159
+                "type": "Arc3D"
+                "plane": {"n": (0, 0, 1), "o": (0, 10, 0), "x": (1, 0, 0)},
+                "radius": 5,
+                "a1": 0,
+                "a2": 3.14159
             }
         """
         return cls(Plane.from_dict(data['plane']), data['radius'],

--- a/ladybug_geometry/geometry3d/cone.py
+++ b/ladybug_geometry/geometry3d/cone.py
@@ -50,10 +50,10 @@ class Cone(object):
         .. code-block:: python
 
             {
-            "type": "Cone"
-            "vertex": (10, 0, 0),
-            "axis": (0, 0, 1),
-            "angle": 1.0,
+                "type": "Cone"
+                "vertex": (10, 0, 0),
+                "axis": (0, 0, 1),
+                "angle": 1.0
             }
         """
         return cls(Point3D.from_array(data['vertex']),

--- a/ladybug_geometry/geometry3d/cylinder.py
+++ b/ladybug_geometry/geometry3d/cylinder.py
@@ -64,10 +64,10 @@ class Cylinder(object):
         .. code-block:: python
 
             {
-            "type": "Cylinder"
-            "center": (10, 0, 0),
-            "axis": (0, 0, 1),
-            "radius": 1.0,
+                "type": "Cylinder"
+                "center": (10, 0, 0),
+                "axis": (0, 0, 1),
+                "radius": 1.0
             }
         """
         return cls(Point3D.from_array(data['center']),

--- a/ladybug_geometry/geometry3d/mesh.py
+++ b/ladybug_geometry/geometry3d/mesh.py
@@ -68,10 +68,10 @@ class Mesh3D(MeshBase):
         .. code-block:: python
 
             {
-            "type": "Mesh3D",
-            "vertices": [(0, 0, 0), (10, 0, 0), (0, 10, 0)],
-            "faces": [(0, 1, 2)],
-            "colors": [{"r": 255, "g": 0, "b": 0}]
+                "type": "Mesh3D",
+                "vertices": [(0, 0, 0), (10, 0, 0), (0, 10, 0)],
+                "faces": [(0, 1, 2)],
+                "colors": [{"r": 255, "g": 0, "b": 0}]
             }
         """
         colors = None

--- a/ladybug_geometry/geometry3d/plane.py
+++ b/ladybug_geometry/geometry3d/plane.py
@@ -65,10 +65,10 @@ class Plane(object):
         .. code-block:: python
 
             {
-            "type": "Plane"
-            "n": (0, 0, 1),
-            "o": (0, 10, 0),
-            "x": (1, 0, 0)
+                "type": "Plane"
+                "n": (0, 0, 1),
+                "o": (0, 10, 0),
+                "x": (1, 0, 0)
             }
         """
         x = None

--- a/ladybug_geometry/geometry3d/pointvector.py
+++ b/ladybug_geometry/geometry3d/pointvector.py
@@ -42,9 +42,9 @@ class Vector3D(object):
         .. code-block:: python
 
             {
-            "x": 10,
-            "y": 0,
-            "z": 0
+                "x": 10,
+                "y": 0,
+                "z": 0
             }
         """
         return cls(data['x'], data['y'], data['z'])
@@ -174,6 +174,15 @@ class Vector3D(object):
                 which the vector will be reflected. THIS VECTOR MUST BE NORMALIZED.
         """
         return Vector3D._reflect(self, normal)
+
+    def project(self, normal):
+        """Get a vector projected into a plane with a given normal.
+
+        Args:
+            normal: A Vector3D representing the normal vector of the plane into which
+                the plane will be projected. THIS VECTOR MUST BE NORMALIZED.
+        """
+        return self - normal * self.dot(normal)
 
     def duplicate(self):
         """Get a copy of this vector."""
@@ -429,7 +438,7 @@ class Point3D(Vector3D):
             return (factor * (self - origin)) + origin
 
     def project(self, normal, origin):
-        """Get a point projected a point3d into a plane with a given normal and origin.
+        """Get a point that is projected into a plane with a given normal and origin.
 
         Args:
             normal: A Vector3D representing the normal vector of the plane into which

--- a/ladybug_geometry/geometry3d/polyface.py
+++ b/ladybug_geometry/geometry3d/polyface.py
@@ -120,11 +120,11 @@ class Polyface3D(Base2DIn3D):
         .. code-block:: python
 
             {
-            "type": "Polyface3D",
-            "vertices": [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0)],
-            "face_indices": [[(0, 1, 2)], [(3, 0, 1)]],
-            "edge_information": {"edge_indices":[(0, 1), (1, 2), (2, 0), (2, 3), (3, 0)],
-                                 "edge_types":[0, 0, 1, 0, 0]}
+                "type": "Polyface3D",
+                "vertices": [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0)],
+                "face_indices": [[(0, 1, 2)], [(3, 0, 1)]],
+                "edge_information": {"edge_indices":[(0, 1), (1, 2), (2, 0), (2, 3), (3, 0)],
+                                    "edge_types":[0, 0, 1, 0, 0]}
             }
         """
         if 'edge_information' in data and data['edge_information'] is not None:

--- a/ladybug_geometry/geometry3d/polyline.py
+++ b/ladybug_geometry/geometry3d/polyline.py
@@ -54,8 +54,8 @@ class Polyline3D(Base2DIn3D):
         .. code-block:: python
 
             {
-            "type": "Polyline3D",
-            "vertices": [(0, 0, 0), (10, 0, 2), (0, 10, 4)]
+                "type": "Polyline3D",
+                "vertices": [(0, 0, 0), (10, 0, 2), (0, 10, 4)]
             }
         """
         interp = data['interpolated'] if 'interpolated' in data else False

--- a/ladybug_geometry/geometry3d/sphere.py
+++ b/ladybug_geometry/geometry3d/sphere.py
@@ -49,9 +49,9 @@ class Sphere(object):
         .. code-block:: python
 
             {
-            "type": "Sphere"
-            "center": (10, 0, 0),
-            "radius": 5,
+                "type": "Sphere"
+                "center": (10, 0, 0),
+                "radius": 5
             }
         """
         return cls(Point3D.from_array(data['center']), data['radius'])

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -572,6 +572,33 @@ def test_upper_left_counter_clockwise_vertices_triangle():
     assert up_cclock_1 == up_cclock_2
 
 
+def test_corner_vertices():
+    """Test the various properties for corner vertices."""
+    plane_1 = Plane(Vector3D(0, 1, 0))
+    plane_2 = Plane(Vector3D(0, -1, 0))
+    pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 0, 2), Point3D(0, 0, 2))
+    pts_2 = (Point3D(0, 0, 0), Point3D(0, 0, 2), Point3D(2, 0, 2), Point3D(2, 0, 0))
+    face_1 = Face3D(pts_1, plane_1)
+    face_2 = Face3D(pts_2, plane_1)
+    face_3 = Face3D(pts_1, plane_2)
+    face_4 = Face3D(pts_2, plane_2)
+
+    assert face_1.upper_left_corner.is_equivalent(Point3D(2, 0, 2), 1e-6)
+    assert face_1.lower_left_corner.is_equivalent(Point3D(2, 0, 0), 1e-6)
+    assert face_1.upper_right_corner.is_equivalent(Point3D(0, 0, 2), 1e-6)
+    assert face_1.lower_right_corner.is_equivalent(Point3D(0, 0, 0), 1e-6)
+
+    assert face_2.upper_left_corner.is_equivalent(Point3D(2, 0, 2), 1e-6)
+    assert face_2.lower_left_corner.is_equivalent(Point3D(2, 0, 0), 1e-6)
+    assert face_2.upper_right_corner.is_equivalent(Point3D(0, 0, 2), 1e-6)
+    assert face_2.lower_right_corner.is_equivalent(Point3D(0, 0, 0), 1e-6)
+
+    assert face_3.upper_left_corner.is_equivalent(Point3D(0, 0, 2), 1e-6)
+    assert face_3.lower_left_corner.is_equivalent(Point3D(0, 0, 0), 1e-6)
+    assert face_3.upper_right_corner.is_equivalent(Point3D(2, 0, 2), 1e-6)
+    assert face_3.lower_right_corner.is_equivalent(Point3D(2, 0, 0), 1e-6)
+
+
 def test_duplicate():
     """Test the duplicate method of Face3D."""
     pts = (Point3D(0, 0, 2), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))

--- a/tests/pointvector3d_test.py
+++ b/tests/pointvector3d_test.py
@@ -302,7 +302,19 @@ def test_reflect():
     assert test_1.z == pytest.approx(2, rel=1e-3)
 
 
-def test_project():
+def test_project_vector3d():
+    """Test the Point3D project method."""
+    v_1 = Vector3D(2, 2, 2)
+    normal_1 = Vector3D(0, 1, 0)
+    normal_2 = Vector3D(1, 0, 0)
+    normal_3 = Vector3D(0, 0, 1)
+
+    assert v_1.project(normal_1) == Vector3D(2, 0, 2)
+    assert v_1.project(normal_2) == Vector3D(0, 2, 2)
+    assert v_1.project(normal_3) == Vector3D(2, 2, 0)
+
+
+def test_project_point3d():
     """Test the Point3D project method."""
     pt_1 = Point3D(2, 2, 2)
     origin_1 = Point3D(1, 0, 0)


### PR DESCRIPTION
This commit adds methods to get the bounding polygon corners around Face3Ds. It also improves the reliability of the upper_left_counter_clockwise_vertices method in the case where the Y-axis is not verticel.