### PR TITLE
fix(face): Reset the Face3D plane information when scaling

### DIFF
--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -877,8 +877,7 @@ class Face3D(Base2DIn3D):
                 If None, it will be scaled from the World origin (0, 0, 0).
         """
         _verts = self._scale(self.vertices, factor, origin)
-        _new_face = self._face_transform_scale(
-            _verts, self.plane.scale(factor, origin), factor)
+        _new_face = self._face_transform_scale(_verts, None, factor)
         if self._holes is not None:
             _new_face._boundary = self._scale(self._boundary, factor, origin)
             _new_face._holes = tuple(self._scale(hole, factor, origin)


### PR DESCRIPTION
It turns out that preserving the plane information while scaling can disrupt some things in cases where we transfer plane information from the CAD interface.

More information is here:
https://discourse.ladybug.tools/t/louvershades-vertical-option-bug/17620