### PR TITLE
fix(polygon): Add an extra check for degenerate geometry

### DIFF
--- a/ladybug_geometry/geometry2d/polygon.py
+++ b/ladybug_geometry/geometry2d/polygon.py
@@ -492,8 +492,10 @@ class Polygon2D(Base2DIn2D):
         height = max_y - min_y
         cell_size = min(width, height)
         h = cell_size / 2.0
-        if cell_size == 0:  # degenerate polygon; just return the minimum
-            return self.min
+        max_dim = max(width, height)
+        if cell_size == 0 or self.area < max_dim * tolerance:
+            # degenerate polygon; just return the center
+            return self.center
 
         # get an array representation of the polygon and set up the priority queue
         _polygon = tuple(pt.to_array() for pt in self.vertices)

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -60,6 +60,13 @@ def test_face3d_pole_of_inaccessibility():
     assert pole.y == pytest.approx(1.0, rel=1e-3)
     assert pole.z == pytest.approx(2.0, rel=1e-3)
 
+    deg_pts = (Point3D(0, 0, 2), Point3D(0, 0.0001, 2),
+               Point3D(2, 0.0001, 2), Point3D(2, 0, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    deg_face = Face3D(deg_pts, plane)
+    deg_pole = deg_face.pole_of_inaccessibility(0.01)
+    assert isinstance(deg_pole, Point3D)
+
 
 def test_equality():
     """Test the equality of Face3D objects."""


### PR DESCRIPTION
This will prevent the pole_of_inaccessibility() function from looping endlessly.