### PR TITLE
fix(face): Ensure that self-intersection check happens for each loop

### DIFF
--- a/ladybug_geometry/geometry2d/polygon.py
+++ b/ladybug_geometry/geometry2d/polygon.py
@@ -194,7 +194,6 @@ class Polygon2D(Base2DIn2D):
         _new_poly = cls(boundary)
         _new_poly._is_clockwise = bound_direction
         _new_poly._is_convex = False
-        _new_poly._is_self_intersecting = False
         return _new_poly
 
     @classmethod
@@ -234,7 +233,6 @@ class Polygon2D(Base2DIn2D):
         _new_poly = cls(boundary)
         _new_poly._is_clockwise = bound_direction
         _new_poly._is_convex = False
-        _new_poly._is_self_intersecting = False
         return _new_poly
 
     @classmethod

--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -499,7 +499,14 @@ class Face3D(Base2DIn3D):
         origin of the geometry is unknown.
         """
         if self._is_self_intersecting is None:
-            self._is_self_intersecting = self.polygon2d.is_self_intersecting
+            self._is_self_intersecting = False
+            if self.boundary_polygon2d.is_self_intersecting:
+                self._is_self_intersecting = True
+            if self.has_holes:
+                for hp in self.hole_polygon2d:
+                    if hp.is_self_intersecting:
+                        self._is_self_intersecting = True
+                        break
         return self._is_self_intersecting
 
     @property

--- a/tests/polygon2d_test.py
+++ b/tests/polygon2d_test.py
@@ -177,7 +177,6 @@ def test_polygon2d_init_from_shape_with_hole():
     assert polygon.perimeter == pytest.approx(26.828427, rel=1e-3)
     assert not polygon.is_clockwise
     assert not polygon.is_convex
-    assert not polygon.is_self_intersecting
 
 
 def test_polygon2d_init_from_shape_with_holes():
@@ -201,7 +200,6 @@ def test_polygon2d_init_from_shape_with_holes():
     assert polygon.perimeter == pytest.approx(26.24264068, rel=1e-3)
     assert not polygon.is_clockwise
     assert not polygon.is_convex
-    assert not polygon.is_self_intersecting
 
 
 def test_clockwise():


### PR DESCRIPTION
This should finally fix the fact that honeybee has not been able to identify self-intersecting Face3Ds.

We're also changing the Polygon2D.is_self_intersecting method to be true to the real shape regardless of whether it was created with the from_shape_with_hole method. This seems like a more honest way of dealing with Polygons were the boundary has been merged into the holes.