### PR TITLE
fix(intersection): Use an absolute tolerance for 2D line intersection

### DIFF
--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -73,8 +73,9 @@ class Face3D(Base2DIn3D):
         * perimeter
         * area
         * centroid
-        * altitude
         * azimuth
+        * altitude
+        * tilt
         * is_clockwise
         * is_convex
         * is_self_intersecting

--- a/ladybug_geometry/intersection2d.py
+++ b/ladybug_geometry/intersection2d.py
@@ -10,9 +10,9 @@ import math
 from .geometry2d.pointvector import Point2D, Vector2D
 
 
-def _isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
+def _isclose(a, b, rel_tol=1e-09, abs_tol=1e-09):
     """Implementation of the math.isclose method from Python 3.5 onward."""
-    return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+    return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 
 def intersect_line2d(line_ray_a, line_ray_b):


### PR DESCRIPTION
This is needed for when the coordinates are very close to zero.