### PR TITLE
fix(polygon): Respect tolerance when removing colinear vertices

### DIFF
--- a/ladybug_geometry/geometry2d/polygon.py
+++ b/ladybug_geometry/geometry2d/polygon.py
@@ -624,7 +624,10 @@ class Polygon2D(Base2DIn2D):
         for i, _v in enumerate(self.vertices):
             _v2, _v1 = self[i - 2 - skip], self[i - 1]
             _a = _v2.determinant(_v1) + _v1.determinant(_v) + _v.determinant(_v2)
-            if abs(_a) >= tolerance:  # triangle area > tolerance; not colinear
+            b_dist = _v.distance_to_point(_v2)
+            b_dist = tolerance if b_dist < tolerance else b_dist
+            tri_tol = (b_dist * tolerance) / 2  # area of triangle with tolerance height
+            if abs(_a) >= tri_tol:  # triangle area > tolerance; not colinear
                 new_vertices.append(self[i - 1])
                 skip = 0
                 if is_first:
@@ -638,7 +641,10 @@ class Polygon2D(Base2DIn2D):
                 'There must be at least 3 vertices for a Polygon2D.'
             _v2, _v1, _v = self[-2 - skip], self[-1], self[first_skip]
             _a = _v2.determinant(_v1) + _v1.determinant(_v) + _v.determinant(_v2)
-            if abs(_a) >= tolerance:  # triangle area > area tolerance; not colinear
+            b_dist = _v.distance_to_point(_v2)
+            b_dist = tolerance if b_dist < tolerance else b_dist
+            tri_tol = (b_dist * tolerance) / 2  # area of triangle with tolerance height
+            if abs(_a) >= tri_tol:  # triangle area > area tolerance; not colinear
                 new_vertices.append(_v1)
         return Polygon2D(new_vertices)
 

--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -2891,7 +2891,10 @@ class Face3D(Base2DIn3D):
         for i, _v in enumerate(pts_2d):
             _v2, _v1 = pts_2d[i - 2 - skip], pts_2d[i - 1]
             _a = _v2.determinant(_v1) + _v1.determinant(_v) + _v.determinant(_v2)
-            if abs(_a) >= tolerance:  # triangle area > area tolerance; not colinear
+            b_dist = _v.distance_to_point(_v2)
+            b_dist = tolerance if b_dist < tolerance else b_dist
+            tri_tol = (b_dist * tolerance) / 2  # area of triangle with tolerance height
+            if abs(_a) >= tri_tol:  # triangle area > area tolerance; not colinear
                 new_vertices.append(pts_3d[i - 1])
                 skip = 0
                 if is_first:
@@ -2905,7 +2908,10 @@ class Face3D(Base2DIn3D):
                 'There must be at least 3 vertices for a Face3D.'
             _v2, _v1, _v = pts_2d[-2 - skip], pts_2d[-1], pts_2d[first_skip]
             _a = _v2.determinant(_v1) + _v1.determinant(_v) + _v.determinant(_v2)
-            if abs(_a) >= tolerance:  # triangle area > area tolerance; not colinear
+            b_dist = _v.distance_to_point(_v2)
+            b_dist = tolerance if b_dist < tolerance else b_dist
+            tri_tol = (b_dist * tolerance) / 2  # area of triangle with tolerance height
+            if abs(_a) >= tri_tol:  # triangle area > area tolerance; not colinear
                 new_vertices.append(pts_3d[-1])
         return new_vertices
 


### PR DESCRIPTION
It seems that the function to remove colinear vertices was too aggressive in some cases and was not aggressive enough in other cases. This is because the criteria to evaluate whether a given vertex is colinear did not account for the distance between the neighboring vertices.

Now, a colinear vertex will only be removed if the distance between it and the line drawn between the two neighboring vertices is less than the tolerance.