### PR TITLE
style(face): Implement better __copy__ method

### DIFF
--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -3298,9 +3298,9 @@ class Face3D(Base2DIn3D):
         return verts3d
 
     def __copy__(self):
-        _new_face = Face3D(self.vertices, self.plane)
+        _new_face = Face3D(self.boundary, self.plane, self.holes,
+                           enforce_right_hand=False)
         self._transfer_properties(_new_face)
-        _new_face._holes = self._holes
         _new_face._polygon2d = self._polygon2d
         _new_face._mesh2d = self._mesh2d
         _new_face._mesh3d = self._mesh3d

--- a/ladybug_geometry/geometry3d/mesh.py
+++ b/ladybug_geometry/geometry3d/mesh.py
@@ -232,7 +232,7 @@ class Mesh3D(MeshBase):
     @property
     def face_edges(self):
         """List of polylines with one Polyline3D for each face.
-        
+
         This is faster to compute compared to the edges and results in effectively
         the same type of wireframe visualization.
         """
@@ -246,7 +246,7 @@ class Mesh3D(MeshBase):
     @property
     def edges(self):
         """"Tuple of all edges in this Mesh3D as LineSegment3D objects.
-        
+
         Note that this method will return only the unique edges in the mesh without
         any duplicates. This is sometimes desirable but can take a lot of time
         to compute for large meshes. For a faster property, use face_edges."""


### PR DESCRIPTION
All of the copy methods really aren't needed since geometry objects are immutable but I can see they might be useful for certain types of advanced editing of underlying properties (that users do at their own peril).

So I'll just leave them as they are and make sure that they work.

Resolves https://github.com/ladybug-tools/ladybug-geometry/issues/404