### PR TITLE
fix(face): Improve accounting for tolerance in room solidity routine

### DIFF
--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -3337,7 +3337,7 @@ class Face3D(Base2DIn3D):
         except (AssertionError, ZeroDivisionError):  # zero area Face3D; use center
             return self.center
 
-        move_vec = move_vec * (tolerance + 0.00001)
+        move_vec = move_vec * (math.sqrt(2 * (tolerance ** 2)) + 0.00001)
         point_on_face = face.boundary[0] + move_vec
         vert2d = face.plane.xyz_to_xy(point_on_face)
         if not face.polygon2d.is_point_inside(vert2d):

--- a/ladybug_geometry/geometry3d/polyface.py
+++ b/ladybug_geometry/geometry3d/polyface.py
@@ -172,7 +172,7 @@ class Polyface3D(Base2DIn3D):
         # get the polyface object and assign correct faces to it
         face_obj = cls(vertices, face_indices)
         if face_obj._is_solid:
-            face_obj._faces = cls.get_outward_faces(faces, 0.01)
+            face_obj._faces = cls.get_outward_faces(faces, tolerance)
         else:
             face_obj._faces = tuple(faces)
         return face_obj
@@ -806,7 +806,7 @@ class Polyface3D(Base2DIn3D):
 
         Args:
             faces: A list of Face3D objects that together form a solid.
-            tolerance: Optional tolerance for the permissable size of gap between
+            tolerance: Optional tolerance for the permissible size of gap between
                 faces at which point the faces are considered to have a single edge.
 
         Returns:


### PR DESCRIPTION
We should be making sure that the _point_on_face is more than the tolerance away from any edge if we want it to work consistently with the tolerance specified in the other routines that use it.