### PR TITLE
fix(polygon2d): Fix edge case bug in Polygon.group_by_touching

### DIFF
--- a/tests/polygon2d_test.py
+++ b/tests/polygon2d_test.py
@@ -1215,7 +1215,7 @@ def test_common_axes():
 
     axes, values = Polygon2D.common_axes(
         polygons, Vector2D(1, 0), min_distance=0.1, merge_distance=0.3,
-        angle_tolerance=math.pi / 180)
+        angle_tolerance=math.pi / 180, filter_tolerance=0)
 
     assert len(axes) == 52
     for item in axes:


### PR DESCRIPTION
This commit also exposes a new option for getting common axes as near-centerlines between polygon edges.