### PR TITLE
fix(mesh): Ensure that triangulated_mesh3d never raises exception

### DIFF
--- a/ladybug_geometry/geometry2d/mesh.py
+++ b/ladybug_geometry/geometry2d/mesh.py
@@ -162,7 +162,14 @@ class Mesh2D(MeshBase):
                         'to use from_polygon_triangulated. Got {}.'.format(type(hole))
             _vertices, _faces = Mesh2D._ear_clipping_triangulation(
                 boundary_polygon, hole_polygons)
-            _new_mesh = cls(_vertices, _faces)
+            if len(_faces) != 0:
+                _new_mesh = cls(_vertices, _faces)
+            else:
+                if len(_vertices) >= 3:
+                    _faces = ((0, 1, 2),)
+                else:
+                    _faces = ((0, 0, 0),)
+                _new_mesh = cls(_vertices, _faces)
 
         return _new_mesh
 

--- a/tests/face3d_test.py
+++ b/tests/face3d_test.py
@@ -882,6 +882,37 @@ def test_triangulated_mesh_edge_case():
     assert face_geo.triangulated_mesh3d.area != 0
 
 
+def test_triangulated_mesh_zero_area():
+    """Test triangulation properties of a zero area Face3D."""
+    verts = (
+        Point3D(40, 94, 41),
+        Point3D(46, 99, 40),
+        Point3D(35, 99, 40),
+        Point3D(35, 99, 40),
+        Point3D(46, 99, 40),
+        Point3D(40, 94, 41),
+        Point3D(35, 99, 40),
+        Point3D(35, 99, 40)
+    )
+    face = Face3D(verts)
+    mesh_1 = face.triangulated_mesh3d
+
+    assert len(mesh_1.vertices) == 8
+    assert len(mesh_1.faces) == 1
+
+    verts2 = (
+        Point3D(0, 0, 0),
+        Point3D(0, 0, 0),
+        Point3D(0, 0, 0)
+    )
+
+    face2 = Face3D(verts2)
+    mesh_2 = face2.triangulated_mesh3d
+
+    assert len(mesh_2.vertices) == 3
+    assert len(mesh_2.faces) == 1
+
+
 def test_check_planar():
     """Test the check_planar method of Face3D."""
     pts_1 = (Point3D(0, 0, 2), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))


### PR DESCRIPTION
We were getting exceptions raised in the case that a Face3D with zero area was used to make a triangulated_mesh3d.

I think the logic follows that, if we allow for the creation of a Face3D with zero area, we should similarly allow it's triangulated Mesh3D to exist with zero area.