### PR TITLE
feat(boolean): Refactor boolean methods so they never fail

### DIFF
--- a/ladybug_geometry/geometry2d/polygon.py
+++ b/ladybug_geometry/geometry2d/polygon.py
@@ -14,6 +14,7 @@ from .pointvector import Point2D, Vector2D
 from .line import LineSegment2D
 from .ray import Ray2D
 from .polyline import Polyline2D
+from ..util import rounding_tolerance
 from ..triangulation import _linked_list, _eliminate_holes
 from ..intersection2d import intersect_line2d, intersect_line2d_infinite, \
     does_intersection_exist_line2d, closest_point2d_on_line2d, \
@@ -1415,15 +1416,6 @@ class Polygon2D(Base2DIn2D):
         b_pts = (pb.BooleanPoint(pt.x, pt.y) for pt in self.vertices)
         return pb.BooleanPolygon([b_pts])
 
-    def _to_snapped_bool_poly(self, snap_ref_polygon, tolerance):
-        """Snap a Polygon2D to this one and translate it to a BooleanPolygon.
-
-        This is necessary to ensure that boolean operations will succeed between
-        two polygons.
-        """
-        new_poly = snap_ref_polygon.snap_to_polygon(self, tolerance)
-        return new_poly._to_bool_poly()
-
     @staticmethod
     def _from_bool_poly(bool_polygon, tolerance=None):
         """Get a list of Polygon2D from a BooleanPolygon object.
@@ -1448,6 +1440,74 @@ class Polygon2D(Base2DIn2D):
                     polys.append(poly)
         return polys
 
+    @staticmethod
+    def preprocess_polygons_for_boolean(polygons, tolerance, are_holes=None):
+        """Clean a set of polygons before performing boolean operations.
+
+        This cleaning is performed by removing all duplicate and colinear vertices
+        from the polygons. Next, the polygon segments are intersected with one
+        another and the polygon vertices are snapped together withing the tolerance.
+        Lastly, the coordinate values os the vertices are rounded to a number
+        of digits derived from the tolerance such that floating point issues
+        do not arise.
+
+        Args:
+            polygons: A list of Polygon2D objects to be processed for boolean
+                operations.
+            tolerance: The minimum distance between points before they are
+                considered distinct from one another.
+            are_holes: An optional list of True/False values to note whether
+                each polygon represents a hole in the previous polygon.
+                These values will be taken into account in the BooleanPolygon
+                objects returned from this method.
+
+        Returns:
+            A lit of BooleanPolygon objects that are ready for boolean operations.
+        """
+        # remove colinear vertices from the polygons within the tolerance
+        all_poly, holes_to_remove = [], []
+        for i, ply in enumerate(polygons):
+            try:
+                all_poly.append(ply.remove_colinear_vertices(tolerance))
+            except AssertionError:  # degenerate polygon to ignore
+                if are_holes is not None:
+                    holes_to_remove.append(i)
+        if len(all_poly) <= 1:
+            return all_poly
+        if len(holes_to_remove) != 0:
+            for h in reversed(holes_to_remove):
+                are_holes.pop(h)
+
+        # next, intersect segments and snap them together
+        all_poly = Polygon2D.intersect_polygon_segments(all_poly, tolerance)
+        all_poly = Polygon2D.snap_polygons(all_poly, tolerance)
+
+        # round all coordinates to something derived from the tolerance
+        rtol, base = rounding_tolerance(tolerance / 10)
+        clean_poly = []
+        for poly in all_poly:
+            clean_pts = []
+            for pt in poly:
+                clean_pt = Point2D(
+                    base * round(pt.x / base, rtol),
+                    base * round(pt.y / base, rtol)
+                )
+                clean_pts.append(clean_pt)
+            clean_poly.append(Polygon2D(clean_pts))
+
+        # create the boolean polygons
+        if are_holes is None:
+            return [poly._to_bool_poly() for poly in clean_poly]
+        else:
+            bool_polys = []
+            for poly, is_hole in zip(clean_poly, are_holes):
+                b_poly = (pb.BooleanPoint(pt.x, pt.y) for pt in poly.vertices)
+                if is_hole:
+                    bool_polys[-1].append(b_poly)
+                else:
+                    bool_polys.append([b_poly])
+            return [pb.BooleanPolygon(bp) for bp in bool_polys]
+
     def boolean_union(self, polygon, tolerance):
         """Get a list of Polygon2D for the union of this Polygon and another.
 
@@ -1468,11 +1528,10 @@ class Polygon2D(Base2DIn2D):
         Returns:
             A list of Polygon2D representing the union of the two polygons.
         """
-        result = pb.union(
-            self._to_bool_poly(),
-            polygon._to_snapped_bool_poly(self, tolerance),
-            tolerance / 1000
-        )
+        bool_polys = self.preprocess_polygons_for_boolean([self, polygon], tolerance)
+        if len(bool_polys) <= 1:
+            return []
+        result = pb.union(bool_polys[0], bool_polys[1], tolerance / 1000)
         return Polygon2D._from_bool_poly(result, tolerance)
 
     def boolean_intersect(self, polygon, tolerance):
@@ -1488,11 +1547,10 @@ class Polygon2D(Base2DIn2D):
             A list of Polygon2D representing the intersection of the two polygons.
             Will be an empty list if no overlap exists between the polygons.
         """
-        result = pb.intersect(
-            self._to_bool_poly(),
-            polygon._to_snapped_bool_poly(self, tolerance),
-            tolerance / 1000
-        )
+        bool_polys = self.preprocess_polygons_for_boolean([self, polygon], tolerance)
+        if len(bool_polys) <= 1:
+            return []
+        result = pb.intersect(bool_polys[0], bool_polys[1], tolerance / 1000)
         return Polygon2D._from_bool_poly(result, tolerance)
 
     def boolean_difference(self, polygon, tolerance):
@@ -1510,11 +1568,10 @@ class Polygon2D(Base2DIn2D):
             elimination of this polygon. Will be the original polygon when there
             is no overlap between the polygons.
         """
-        result = pb.difference(
-            self._to_bool_poly(),
-            polygon._to_snapped_bool_poly(self, tolerance),
-            tolerance / 1000
-        )
+        bool_polys = self.preprocess_polygons_for_boolean([self, polygon], tolerance)
+        if len(bool_polys) <= 1:
+            return []
+        result = pb.difference(bool_polys[0], bool_polys[1], tolerance / 1000)
         return Polygon2D._from_bool_poly(result, tolerance)
 
     def boolean_xor(self, polygon, tolerance):
@@ -1542,11 +1599,10 @@ class Polygon2D(Base2DIn2D):
             two polygons. Will be the original polygons when there is no overlap
             in the two.
         """
-        result = pb.xor(
-            self._to_bool_poly(),
-            polygon._to_snapped_bool_poly(self, tolerance),
-            tolerance / 1000
-        )
+        bool_polys = self.preprocess_polygons_for_boolean([self, polygon], tolerance)
+        if len(bool_polys) <= 1:
+            return []
+        result = pb.xor(bool_polys[0], bool_polys[1], tolerance / 1000)
         return Polygon2D._from_bool_poly(result, tolerance)
 
     @staticmethod
@@ -1596,8 +1652,9 @@ class Polygon2D(Base2DIn2D):
         Returns:
             A list of Polygon2D representing the union of all the polygons.
         """
-        polygons = Polygon2D.snap_polygons(polygons, tolerance)
-        bool_polys = [poly._to_bool_poly() for poly in polygons]
+        bool_polys = Polygon2D.preprocess_polygons_for_boolean(polygons, tolerance)
+        if len(bool_polys) <= 1:
+            return []
         result = pb.union_all(bool_polys, tolerance / 1000)
         return Polygon2D._from_bool_poly(result, tolerance)
 
@@ -1626,8 +1683,9 @@ class Polygon2D(Base2DIn2D):
             A list of Polygon2D representing the intersection of all the polygons.
             Will be an empty list if no overlap exists between the polygons.
         """
-        polygons = Polygon2D.snap_polygons(polygons, tolerance)
-        bool_polys = [poly._to_bool_poly() for poly in polygons]
+        bool_polys = Polygon2D.preprocess_polygons_for_boolean(polygons, tolerance)
+        if len(bool_polys) <= 1:
+            return []
         result = pb.intersect_all(bool_polys, tolerance / 1000)
         return Polygon2D._from_bool_poly(result, tolerance)
 
@@ -1666,11 +1724,12 @@ class Polygon2D(Base2DIn2D):
             not overlap with polygon1. When combined with the intersection, this
             makes a split version of polygon2.
         """
-        int_result, poly1_result, poly2_result = pb.split(
-            polygon1._to_bool_poly(),
-            polygon2._to_snapped_bool_poly(polygon1, tolerance),
-            tolerance / 1000
-        )
+        polygons = [polygon1, polygon2]
+        bool_polys = Polygon2D.preprocess_polygons_for_boolean(polygons, tolerance)
+        if len(bool_polys) <= 1:
+            return []
+        int_result, poly1_result, poly2_result = \
+            pb.split(bool_polys[0], bool_polys[1], tolerance / 1000)
         intersection = Polygon2D._from_bool_poly(int_result, tolerance)
         poly1_difference = Polygon2D._from_bool_poly(poly1_result, tolerance)
         poly2_difference = Polygon2D._from_bool_poly(poly2_result, tolerance)
@@ -2373,24 +2432,18 @@ class Polygon2D(Base2DIn2D):
             all_poly.append(offset_poly)
 
         # boolean union the polygons together
-        all_poly = Polygon2D.snap_polygons(all_poly, tolerance)
-        bool_polys = []  # create BooleanPolygons
-        for ply in all_poly:
-            bool_pts = [pb.BooleanPoint(pt.x, pt.y) for pt in ply.vertices]
-            bool_polys.append(pb.BooleanPolygon([bool_pts]))
-        int_tol = tolerance / 300
+        bool_polys = Polygon2D.preprocess_polygons_for_boolean(all_poly, tolerance)
+        if len(bool_polys) <= 1:
+            return []
+        int_tol = tolerance / 1000
         try:
             poly_result = pb.union_all(bool_polys, int_tol)
         except Exception:  # tiny edge caused a failure; try with small tol
-            int_tol = int_tol / 10
+            int_tol = int_tol / 100
             try:
                 poly_result = pb.union_all(bool_polys, int_tol)
             except Exception:
-                int_tol = int_tol / 10
-                try:
-                    poly_result = pb.union_all(bool_polys, int_tol)
-                except Exception:
-                    poly_result = None  # the edge is just too tiny
+                poly_result = None  # the edge is just too tiny
 
         # serialize the BooleanPolygon into Polygon2D
         polys = []

--- a/ladybug_geometry/geometry3d/face.py
+++ b/ladybug_geometry/geometry3d/face.py
@@ -2571,21 +2571,20 @@ class Face3D(Base2DIn3D):
             A List of Face3D representing the original Face3D with the input faces
             subtracted from it.
         """
-        # define the primary boolean polygon
-        prim_pl = self.plane
-        f1_poly = self.boundary_polygon2d
-        try:
-            f1_poly = f1_poly.remove_colinear_vertices(tolerance)
+        try:  # first be sure that the input is not degenerate
+            f1_poly = self.boundary_polygon2d.remove_colinear_vertices(tolerance)
         except AssertionError:  # degenerate face input
             return [self]
-        f1_polys = [(pb.BooleanPoint(pt.x, pt.y) for pt in f1_poly.vertices)]
+
+        # get the primary plane and polygons
+        prim_pl = self.plane
+        all_poly, are_holes = [f1_poly], [False]
         if self.has_holes:
             for hole in self.hole_polygon2d:
-                f1_polys.append((pb.BooleanPoint(pt.x, pt.y) for pt in hole.vertices))
-        b_poly1 = pb.BooleanPolygon(f1_polys)
+                all_poly.append(hole)
+                are_holes.append(True)
 
-        # pre-process the Face3Ds to be intersected
-        relevant_b_polys = []
+        # add all of the secondary polygons
         for face2 in faces:
             # test whether the faces are coplanar
             if not prim_pl.is_coplanar_tolerance(face2.plane, tolerance, angle_tolerance):
@@ -2594,24 +2593,24 @@ class Face3D(Base2DIn3D):
             f2_poly = Polygon2D(tuple(prim_pl.xyz_to_xy(pt) for pt in face2.boundary))
             if f1_poly.polygon_relationship(f2_poly, tolerance) == -1:
                 continue
-            # snap the polygons to one another to avoid tolerance issues
             try:
                 f2_poly = f2_poly.remove_colinear_vertices(tolerance)
             except AssertionError:  # degenerate faces input
                 continue
-            s2_poly = f1_poly.snap_to_polygon(f2_poly, tolerance)
-            # get BooleanPolygons of the two faces
-            f2_polys = [(pb.BooleanPoint(pt.x, pt.y) for pt in s2_poly.vertices)]
+            all_poly.append(f2_poly)
+            are_holes.append(False)
             if face2.has_holes:
                 for hole in face2.holes:
-                    h_pt2d = (prim_pl.xyz_to_xy(pt) for pt in hole)
-                    f2_polys.append((pb.BooleanPoint(pt.x, pt.y) for pt in h_pt2d))
-            b_poly2 = pb.BooleanPolygon(f2_polys)
-            relevant_b_polys.append(b_poly2)
+                    h_pt2d = Polygon2D(tuple(prim_pl.xyz_to_xy(pt) for pt in hole))
+                    all_poly.append(h_pt2d)
+                    are_holes.append(True)
 
-        # if no relevant polygons were found, return self
-        if len(relevant_b_polys) == 0:
+        # preprocess the polygons for a boolean operation
+        b_polys = Polygon2D.preprocess_polygons_for_boolean(all_poly, tolerance, are_holes)
+        if len(b_polys) <= 1:
             return [self]
+        b_poly1 = b_polys[0]
+        relevant_b_polys = b_polys[1:]
 
         # loop through the boolean polygons and subtract them
         int_tol = tolerance / 1000
@@ -2653,25 +2652,32 @@ class Face3D(Base2DIn3D):
         f2_poly = Polygon2D(tuple(prim_pl.xyz_to_xy(pt) for pt in face2.boundary))
         if f1_poly.polygon_relationship(f2_poly, tolerance) == -1:
             return None
-        # snap the polygons to one another to avoid tolerance issues
+        # check that neither of the inputs are degenerate
         try:
             f1_poly = f1_poly.remove_colinear_vertices(tolerance)
             f2_poly = f2_poly.remove_colinear_vertices(tolerance)
         except AssertionError:  # degenerate faces input
             return None
-        s2_poly = f1_poly.snap_to_polygon(f2_poly, tolerance)
-        # get BooleanPolygons of the two faces
-        f1_polys = [(pb.BooleanPoint(pt.x, pt.y) for pt in f1_poly.vertices)]
-        f2_polys = [(pb.BooleanPoint(pt.x, pt.y) for pt in s2_poly.vertices)]
+        # convert the polygons to all be in the same plane
+        all_poly, are_holes = [f1_poly], [False]
         if face1.has_holes:
             for hole in face1.hole_polygon2d:
-                f1_polys.append((pb.BooleanPoint(pt.x, pt.y) for pt in hole.vertices))
+                all_poly.append(hole)
+                are_holes.append(True)
+        all_poly.append(f2_poly)
+        are_holes.append(False)
         if face2.has_holes:
             for hole in face2.holes:
-                h_pt2d = (prim_pl.xyz_to_xy(pt) for pt in hole)
-                f2_polys.append((pb.BooleanPoint(pt.x, pt.y) for pt in h_pt2d))
-        b_poly1 = pb.BooleanPolygon(f1_polys)
-        b_poly2 = pb.BooleanPolygon(f2_polys)
+                h_pt2d = Polygon2D(prim_pl.xyz_to_xy(pt) for pt in hole)
+                all_poly.append(h_pt2d)
+                are_holes.append(True)
+
+        # preprocess the polygons for a boolean operation
+        b_polys = Polygon2D.preprocess_polygons_for_boolean(all_poly, tolerance, are_holes)
+        if len(b_polys) <= 1:
+            return None
+        b_poly1, b_poly2 = b_polys[0], b_polys[1]
+
         # union the two boolean polygons with one another
         int_tol = tolerance / 1000
         try:
@@ -2714,25 +2720,32 @@ class Face3D(Base2DIn3D):
         f2_poly = Polygon2D(tuple(prim_pl.xyz_to_xy(pt) for pt in face2.boundary))
         if f1_poly.polygon_relationship(f2_poly, tolerance) == -1:
             return None
-        # snap the polygons to one another to avoid tolerance issues
+        # check that neither of the inputs are degenerate
         try:
             f1_poly = f1_poly.remove_colinear_vertices(tolerance)
             f2_poly = f2_poly.remove_colinear_vertices(tolerance)
         except AssertionError:  # degenerate faces input
             return None
-        s2_poly = f1_poly.snap_to_polygon(f2_poly, tolerance)
-        # get BooleanPolygons of the two faces
-        f1_polys = [(pb.BooleanPoint(pt.x, pt.y) for pt in f1_poly.vertices)]
-        f2_polys = [(pb.BooleanPoint(pt.x, pt.y) for pt in s2_poly.vertices)]
+        # convert the polygons to all be in the same plane
+        all_poly, are_holes = [f1_poly], [False]
         if face1.has_holes:
             for hole in face1.hole_polygon2d:
-                f1_polys.append((pb.BooleanPoint(pt.x, pt.y) for pt in hole.vertices))
+                all_poly.append(hole)
+                are_holes.append(True)
+        all_poly.append(f2_poly)
+        are_holes.append(False)
         if face2.has_holes:
             for hole in face2.holes:
-                h_pt2d = (prim_pl.xyz_to_xy(pt) for pt in hole)
-                f2_polys.append((pb.BooleanPoint(pt.x, pt.y) for pt in h_pt2d))
-        b_poly1 = pb.BooleanPolygon(f1_polys)
-        b_poly2 = pb.BooleanPolygon(f2_polys)
+                h_pt2d = Polygon2D(prim_pl.xyz_to_xy(pt) for pt in hole)
+                all_poly.append(h_pt2d)
+                are_holes.append(True)
+
+        # preprocess the polygons for a boolean operation
+        b_polys = Polygon2D.preprocess_polygons_for_boolean(all_poly, tolerance, are_holes)
+        if len(b_polys) <= 1:
+            return None
+        b_poly1, b_poly2 = b_polys[0], b_polys[1]
+
         # intersect the two boolean polygons with one another
         int_tol = tolerance / 1000
         try:
@@ -2778,37 +2791,32 @@ class Face3D(Base2DIn3D):
         f2_poly = Polygon2D(tuple(prim_pl.xyz_to_xy(pt) for pt in face2.boundary))
         if f1_poly.polygon_relationship(f2_poly, tolerance) == -1:
             return [face1], [face2]
-        # snap the polygons to one another to avoid tolerance issues
+        # check that neither of the inputs are degenerate
         try:
             f1_poly = f1_poly.remove_colinear_vertices(tolerance)
             f2_poly = f2_poly.remove_colinear_vertices(tolerance)
         except AssertionError:  # degenerate faces input
             return [face1], [face2]
-        s2_poly = f1_poly.snap_to_polygon(f2_poly, tolerance)
-        # get BooleanPolygons of the two faces
-        f1_polys = [(pb.BooleanPoint(pt.x, pt.y) for pt in f1_poly.vertices)]
-        f2_polys = [(pb.BooleanPoint(pt.x, pt.y) for pt in s2_poly.vertices)]
-        if face1.has_holes and face2.has_holes:  # snap corresponding holes together
-            f1h_polys = face1.hole_polygon2d
-            f2h_polys = [Polygon2D(tuple(prim_pl.xyz_to_xy(pt) for pt in h_pts))
-                         for h_pts in face2.holes]
-            for f1hp in f1h_polys:
-                for hi, f2hp in enumerate(f2h_polys):
-                    if f1hp.center.distance_to_point(f2hp.center) < tolerance:
-                        f2h_polys[hi] = f1hp.snap_to_polygon(f2hp, tolerance)
-            for hole in f1h_polys:
-                f1_polys.append((pb.BooleanPoint(pt.x, pt.y) for pt in hole.vertices))
-            for hole in f2h_polys:
-                f2_polys.append((pb.BooleanPoint(pt.x, pt.y) for pt in hole.vertices))
-        elif face1.has_holes:
+        # convert the polygons to all be in the same plane
+        all_poly, are_holes = [f1_poly], [False]
+        if face1.has_holes:
             for hole in face1.hole_polygon2d:
-                f1_polys.append((pb.BooleanPoint(pt.x, pt.y) for pt in hole.vertices))
-        elif face2.has_holes:
+                all_poly.append(hole)
+                are_holes.append(True)
+        all_poly.append(f2_poly)
+        are_holes.append(False)
+        if face2.has_holes:
             for hole in face2.holes:
-                h_pt2d = (prim_pl.xyz_to_xy(pt) for pt in hole)
-                f2_polys.append((pb.BooleanPoint(pt.x, pt.y) for pt in h_pt2d))
-        b_poly1 = pb.BooleanPolygon(f1_polys)
-        b_poly2 = pb.BooleanPolygon(f2_polys)
+                h_pt2d = Polygon2D(prim_pl.xyz_to_xy(pt) for pt in hole)
+                all_poly.append(h_pt2d)
+                are_holes.append(True)
+
+        # preprocess the polygons for a boolean operation
+        b_polys = Polygon2D.preprocess_polygons_for_boolean(all_poly, tolerance, are_holes)
+        if len(b_polys) <= 1:
+            return None
+        b_poly1, b_poly2 = b_polys[0], b_polys[1]
+
         # split the two boolean polygons with one another
         int_tol = tolerance / 1000
         try:
@@ -2820,6 +2828,7 @@ class Face3D(Base2DIn3D):
                     pb.split(b_poly1, b_poly2, int_tol)
             except Exception:
                 return [face1], [face2]  # the edge is just too tiny
+
         # rebuild the Face3D from the results and return them
         int_faces = Face3D._from_bool_poly(int_result, prim_pl, tolerance)
         poly1_faces = Face3D._from_bool_poly(poly1_result, prim_pl, tolerance)
@@ -2846,55 +2855,59 @@ class Face3D(Base2DIn3D):
 
         Returns:
             A list of Face3D for the Union of all the input Face3D. When the faces
-            are not coplanar, None will be returned.
+            are not all coplanar with one another, None will be returned.
         """
-        # test whether the faces are coplanar
-        prim_pl = faces[0].plane
-        for of in faces[1:]:
-            if not prim_pl.is_coplanar_tolerance(of.plane, tolerance, angle_tolerance):
-                return None
-        # convert all boundaries and holes to 2D space
-        hole_decoder = [False]
-        all_poly = [faces[0].boundary_polygon2d]
-        if faces[0].has_holes:
-            for hole in faces[0].hole_polygon2d:
-                all_poly.append(hole)
-                hole_decoder.append(True)
-        for of in faces[1:]:
-            of_poly = Polygon2D(tuple(prim_pl.xyz_to_xy(pt) for pt in of.boundary))
-            all_poly.append(of_poly)
-            hole_decoder.append(False)
-            if of.has_holes:
-                for hole in of.holes:
-                    h_poly = Polygon2D(tuple(prim_pl.xyz_to_xy(pt) for pt in hole))
-                    all_poly.append(h_poly)
-                    hole_decoder.append(True)
-        # snap the polygons to one another to avoid tolerance issues
+        # first be sure that the input is not empty or degenerate
+        if len(faces) == 0:
+            return []
+        f1 = faces[0]
         try:
-            all_poly = [ply.remove_colinear_vertices(tolerance) for ply in all_poly]
-        except AssertionError:  # degenerate faces input
+            f1_poly = f1.boundary_polygon2d.remove_colinear_vertices(tolerance)
+        except AssertionError:  # degenerate face input
             return None
-        all_poly = Polygon2D.snap_polygons(all_poly, tolerance)
-        # create BooleanPolygons of the faces
-        bool_polys = []
-        prev_poly = None
-        for ply, is_hole in zip(all_poly, hole_decoder):
-            bool_pts = (pb.BooleanPoint(pt.x, pt.y) for pt in ply.vertices)
-            if not is_hole:
-                if prev_poly is not None:
-                    bool_polys.append(pb.BooleanPolygon(prev_poly))
-                prev_poly = [bool_pts]
-            else:
-                prev_poly.append(bool_pts)
-        bool_polys.append(pb.BooleanPolygon(prev_poly))
+
+        # get the primary plane and polygons
+        prim_pl = f1.plane
+        all_poly, are_holes = [f1_poly], [False]
+        if f1.has_holes:
+            for hole in f1.hole_polygon2d:
+                all_poly.append(hole)
+                are_holes.append(True)
+
+        # add all of the secondary polygons
+        for face2 in faces[1:]:
+            # test whether the faces are coplanar
+            if not prim_pl.is_coplanar_tolerance(face2.plane, tolerance, angle_tolerance):
+                continue
+            # test whether the two polygons have any overlap in 2D space
+            f2_poly = Polygon2D(tuple(prim_pl.xyz_to_xy(pt) for pt in face2.boundary))
+            if f1_poly.polygon_relationship(f2_poly, tolerance) == -1:
+                continue
+            try:
+                f2_poly = f2_poly.remove_colinear_vertices(tolerance)
+            except AssertionError:  # degenerate face input
+                continue
+            all_poly.append(f2_poly)
+            are_holes.append(False)
+            if face2.has_holes:
+                for hole in face2.holes:
+                    h_pt2d = Polygon2D(tuple(prim_pl.xyz_to_xy(pt) for pt in hole))
+                    all_poly.append(h_pt2d)
+                    are_holes.append(True)
+
+        # preprocess the polygons for a boolean operation
+        b_polys = Polygon2D.preprocess_polygons_for_boolean(all_poly, tolerance, are_holes)
+        if len(b_polys) <= 1:
+            return None
+
         # union the boolean polygons with one another
         int_tol = tolerance / 1000
         try:
-            poly_result = pb.union_all(bool_polys, int_tol)
+            poly_result = pb.union_all(b_polys, int_tol)
         except Exception:  # tiny edge caused a failure; try with small tol
             int_tol = int_tol / 100
             try:
-                poly_result = pb.union_all(bool_polys, int_tol)
+                poly_result = pb.union_all(b_polys, int_tol)
             except Exception:
                 return None  # the edge is just too tiny
         # rebuild the Face3D from the results and return them

--- a/ladybug_geometry/util.py
+++ b/ladybug_geometry/util.py
@@ -3,6 +3,42 @@ from __future__ import division
 import math
 
 
+def rounding_tolerance(tolerance):
+    """Get the number of digits to round coordinate value to given a tolerance.
+
+    To get coordinate values that are perfectly equal to one another within floating
+    point tolerance using this method, the outputs should be used in the following way.
+
+    .. code-block:: python
+
+        rounded_coordinate_value = base * round(coordinate_value / base, rtol)
+
+    Args:
+        tolerance: A number for the smallest difference in coordinate values
+            considered meaningful.
+
+    Returns:
+        A tuple with two elements
+
+            -   rtol: An integer for the number of digits to round values to.
+
+            -   base: A number to account for cases where the input tolerance
+                is not base 10.
+    """
+    # get the relative tolerance using a log function
+    try:
+        rtol = int(math.log10(tolerance)) * -1
+    except ValueError:
+        rtol = 0  # the tolerance is equal to 1 (out of range for log)
+    # account for the fact that the tolerance may not be base 10
+    base = int(tolerance * 10 ** (rtol + 1))
+    if base == 10 or base == 0:  # tolerance is base 10 (eg. 0.001)
+        base = 1
+    else:  # tolerance is not base 10 (eg. 0.003)
+        rtol += 1
+    return rtol, base
+
+
 def coordinates_hash(point, tolerance):
     """Convert XY coordinates of a Point2D into a string useful for hashing.
 
@@ -13,22 +49,14 @@ def coordinates_hash(point, tolerance):
 
     Args:
         point: A Point2D object.
-        tolerance: floating point precision tolerance.
+        tolerance: A number for the smallest difference in coordinate values
+            considered meaningful.
 
     Returns:
         A string of rounded coordinates.
     """
     # get the relative tolerance using a log function
-    try:
-        rtol = int(math.log10(tolerance)) * -1
-    except ValueError:
-        rtol = 0  # the tol is equal to 1 (out of range for log)
-    # account for the fact that the tolerance may not be base 10
-    base = int(tolerance * 10 ** (rtol + 1))
-    if base == 10 or base == 0:  # tolerance is base 10 (eg. 0.001)
-        base = 1
-    else:  # tolerance is not base 10 (eg. 0.003)
-        rtol += 1
+    rtol, base = rounding_tolerance(tolerance)
     # avoid cases of signed zeros messing with the hash
     z_tol = tolerance / 2
     x_val = 0.0 if abs(point.x) < z_tol else point.x
@@ -50,22 +78,13 @@ def coordinates_hash_3d(point, tolerance):
 
     Args:
         point: A Point3D object.
-        tolerance: floating point precision tolerance.
-
+        tolerance: A number for the smallest difference in coordinate values
+            considered meaningful.
     Returns:
         A string of rounded coordinates.
     """
     # get the relative tolerance using a log function
-    try:
-        rtol = int(math.log10(tolerance)) * -1
-    except ValueError:
-        rtol = 0  # the tol is equal to 1 (out of range for log)
-    # account for the fact that the tolerance may not be base 10
-    base = int(tolerance * 10 ** (rtol + 1))
-    if base == 10 or base == 0:  # tolerance is base 10 (eg. 0.001)
-        base = 1
-    else:  # tolerance is not base 10 (eg. 0.003)
-        rtol += 1
+    rtol, base = rounding_tolerance(tolerance)
     # avoid cases of signed zeros messing with the hash
     z_tol = tolerance / 2
     x_val = 0.0 if abs(point.x) < z_tol else point.x


### PR DESCRIPTION
Finally, I have not been able to get a boolean operation to fail out of all the complex cases we have collected.

These people helped me figure it out:
https://github.com/mziadd/poly_bool_dart/issues/6

All it really took was rounding the coordinate values to something that was smaller than the input tolerance (to preserve user input accuracy) but was larger than the polybool epsilon value.